### PR TITLE
Update copyright year to 2022 - Closes #4

### DIFF
--- a/src/abomination/AppGroup.vala
+++ b/src/abomination/AppGroup.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2018-2021 Budgie Desktop Developers
+ * Copyright © 2018-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/abomination/RunningApp.vala
+++ b/src/abomination/RunningApp.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2018-2021 Budgie Desktop Developers
+ * Copyright © 2018-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/abomination/abomination.vala
+++ b/src/abomination/abomination.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2018-2021 Budgie Desktop Developers
+ * Copyright © 2018-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/abomination/utils.vala
+++ b/src/abomination/utils.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2018-2021 Budgie Desktop Developers
+ * Copyright © 2018-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/budgie-menu/BudgieMenu.plugin.in
+++ b/src/applets/budgie-menu/BudgieMenu.plugin.in
@@ -3,6 +3,6 @@ Module=budgiemenuapplet.so
 Name=Budgie Menu
 _Description=Budgie Menu
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2014-2021 Budgie Desktop Developers
+Copyright=Copyright © 2014-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=view-grid-symbolic

--- a/src/applets/budgie-menu/BudgieMenu.vala
+++ b/src/applets/budgie-menu/BudgieMenu.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/budgie-menu/BudgieMenuButtons.vala
+++ b/src/applets/budgie-menu/BudgieMenuButtons.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/src/applets/budgie-menu/BudgieMenuWindow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/budgie-menu/IconChooser.vala
+++ b/src/applets/budgie-menu/IconChooser.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2017-2021 Budgie Desktop Developers
+ * Copyright © 2017-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/caffeine/CaffeineApplet.plugin.in
+++ b/src/applets/caffeine/CaffeineApplet.plugin.in
@@ -3,6 +3,6 @@ Module=caffeineapplet.so
 Name=Caffeine
 _Description=Caffeine
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2018-2021 Budgie Desktop Developers
+Copyright=Copyright © 2018-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org/
 Icon=my-caffeine-on-symbolic

--- a/src/applets/caffeine/CaffeineApplet.vala
+++ b/src/applets/caffeine/CaffeineApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2018-2021 Budgie Desktop Developers
+ * Copyright © 2018-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/caffeine/CaffeineSettings.vala
+++ b/src/applets/caffeine/CaffeineSettings.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2018-2021 Budgie Desktop Developers
+ * Copyright © 2018-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/caffeine/CaffeineWindow.vala
+++ b/src/applets/caffeine/CaffeineWindow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2018-2021 Budgie Desktop Developers
+ * Copyright © 2018-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/clock/ClockApplet.plugin.in
+++ b/src/applets/clock/ClockApplet.plugin.in
@@ -3,6 +3,6 @@ Module=clockapplet.so
 Name=Clock
 _Description=Clock
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2014-2021 Budgie Desktop Developers
+Copyright=Copyright © 2014-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=clock-applet-symbolic

--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2014-2021 Budgie Desktop Developers
+ * Copyright © 2014-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/icon-tasklist/ButtonWrapper.vala
+++ b/src/applets/icon-tasklist/ButtonWrapper.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/icon-tasklist/DesktopHelper.vala
+++ b/src/applets/icon-tasklist/DesktopHelper.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/icon-tasklist/Icon.vala
+++ b/src/applets/icon-tasklist/Icon.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2017-2021 Budgie Desktop Developers
+ * Copyright © 2017-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/icon-tasklist/IconButton.vala
+++ b/src/applets/icon-tasklist/IconButton.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/icon-tasklist/IconPopover.vala
+++ b/src/applets/icon-tasklist/IconPopover.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2018-2021 Budgie Desktop Developers
+ * Copyright © 2018-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/icon-tasklist/IconTasklistApplet.plugin.in
+++ b/src/applets/icon-tasklist/IconTasklistApplet.plugin.in
@@ -3,6 +3,6 @@ Module=icontasklistapplet.so
 Name=Icon Task List
 _Description=Icon Task List
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2015-2021 Budgie Desktop Developers
+Copyright=Copyright © 2015-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=icon-task-list-symbolic

--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/icon-tasklist/animation.vala
+++ b/src/applets/icon-tasklist/animation.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/applets/keyboard-layout/KeyboardLayoutApplet.plugin.in
+++ b/src/applets/keyboard-layout/KeyboardLayoutApplet.plugin.in
@@ -3,6 +3,6 @@ Module=keyboardlayoutapplet.so
 Name=Keyboard Layout
 _Description=Keyboard Layout Indicator
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2016-2021 Budgie Desktop Developers
+Copyright=Copyright © 2016-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=input-keyboard-symbolic

--- a/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
+++ b/src/applets/keyboard-layout/KeyboardLayoutApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/lock-keys/LockKeysApplet.plugin.in
+++ b/src/applets/lock-keys/LockKeysApplet.plugin.in
@@ -3,6 +3,6 @@ Module=lockkeysapplet.so
 Name=Lock Keys Indicator
 _Description=Lock Keys Indicator
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2015-2021 Budgie Desktop Developers
+Copyright=Copyright © 2015-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=num-lock-symbolic

--- a/src/applets/lock-keys/LockKeysApplet.vala
+++ b/src/applets/lock-keys/LockKeysApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/night-light/IndicatorWindow.vala
+++ b/src/applets/night-light/IndicatorWindow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2017-2021 Budgie Desktop Developers
+ * Copyright © 2017-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/night-light/NightLight.plugin.in
+++ b/src/applets/night-light/NightLight.plugin.in
@@ -3,6 +3,6 @@ Module=nightlightapplet.so
 Name=Night Light
 _Description=Night Light
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2017-2021 Budgie Desktop Developers
+Copyright=Copyright © 2017-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=weather-clear-night-symbolic

--- a/src/applets/night-light/NightLight.vala
+++ b/src/applets/night-light/NightLight.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2017-2021 Budgie Desktop Developers
+ * Copyright © 2017-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/notifications/NotificationsApplet.plugin.in
+++ b/src/applets/notifications/NotificationsApplet.plugin.in
@@ -3,6 +3,6 @@ Module=notificationsapplet.so
 Name=Notifications
 _Description=Notifications
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2015-2021 Budgie Desktop Developers
+Copyright=Copyright © 2015-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=notifications-applet-symbolic

--- a/src/applets/notifications/NotificationsApplet.vala
+++ b/src/applets/notifications/NotificationsApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/ListItem.vala
+++ b/src/applets/places-indicator/ListItem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/MessageRevealer.vala
+++ b/src/applets/places-indicator/MessageRevealer.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/MountHelper.vala
+++ b/src/applets/places-indicator/MountHelper.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/MountItem.vala
+++ b/src/applets/places-indicator/MountItem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/PlaceItem.vala
+++ b/src/applets/places-indicator/PlaceItem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/PlacesIndicator.plugin.in
+++ b/src/applets/places-indicator/PlacesIndicator.plugin.in
@@ -3,6 +3,6 @@ Module=libplacesindicator.so
 Name=Places
 _Description=Places
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2016-2021 Budgie Desktop Developers
+Copyright=Copyright © 2016-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=folder-symbolic

--- a/src/applets/places-indicator/PlacesIndicator.vala
+++ b/src/applets/places-indicator/PlacesIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/PlacesIndicatorWindow.vala
+++ b/src/applets/places-indicator/PlacesIndicatorWindow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/PlacesSection.vala
+++ b/src/applets/places-indicator/PlacesSection.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/places-indicator/VolumeItem.vala
+++ b/src/applets/places-indicator/VolumeItem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/raven-trigger/RavenTriggerApplet.plugin.in
+++ b/src/applets/raven-trigger/RavenTriggerApplet.plugin.in
@@ -3,6 +3,6 @@ Module=raventriggerapplet.so
 Name=Raven Trigger
 _Description=Raven Sidebar Control
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2016-2021 Budgie Desktop Developers
+Copyright=Copyright © 2016-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=pane-show-symbolic

--- a/src/applets/raven-trigger/RavenTriggerApplet.vala
+++ b/src/applets/raven-trigger/RavenTriggerApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/separator/SeparatorApplet.plugin.in
+++ b/src/applets/separator/SeparatorApplet.plugin.in
@@ -3,6 +3,6 @@ Module=separatorapplet.so
 Name=Separator
 _Description=Separator
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2015-2021 Budgie Desktop Developers
+Copyright=Copyright © 2015-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=separator-symbolic

--- a/src/applets/separator/SeparatorApplet.vala
+++ b/src/applets/separator/SeparatorApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/show-desktop/ShowDesktopApplet.plugin.in
+++ b/src/applets/show-desktop/ShowDesktopApplet.plugin.in
@@ -3,6 +3,6 @@ Module=showdesktopapplet.so
 Name=Show Desktop Button
 _Description=Show Desktop Button
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2015-2021 Budgie Desktop Developers
+Copyright=Copyright © 2015-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=user-desktop-symbolic

--- a/src/applets/show-desktop/ShowDesktopApplet.vala
+++ b/src/applets/show-desktop/ShowDesktopApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/spacer/SpacerApplet.plugin.in
+++ b/src/applets/spacer/SpacerApplet.plugin.in
@@ -3,6 +3,6 @@ Module=spacerapplet.so
 Name=Spacer
 _Description=Spacer
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2015-2021 Budgie Desktop Developers
+Copyright=Copyright © 2015-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=spacer-symbolic

--- a/src/applets/spacer/SpacerApplet.vala
+++ b/src/applets/spacer/SpacerApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/status/BluetoothIndicator.vala
+++ b/src/applets/status/BluetoothIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  * Copyright (C) 2015 Alberts Muktupāvels
  *
  * This program is free software; you can redistribute it and/or modify

--- a/src/applets/status/PowerIndicator.vala
+++ b/src/applets/status/PowerIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/status/SoundIndicator.vala
+++ b/src/applets/status/SoundIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/status/StatusApplet.plugin.in
+++ b/src/applets/status/StatusApplet.plugin.in
@@ -3,6 +3,6 @@ Module=statusapplet.so
 Name=Status Indicator
 _Description=Status Indicator
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2015-2021 Budgie Desktop Developers
+Copyright=Copyright © 2015-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=avatar-default-symbolic

--- a/src/applets/status/StatusApplet.vala
+++ b/src/applets/status/StatusApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/tasklist/TasklistApplet.plugin.in
+++ b/src/applets/tasklist/TasklistApplet.plugin.in
@@ -3,6 +3,6 @@ Module=tasklistapplet.so
 Name=Task List
 _Description=Task List
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2015-2021 Budgie Desktop Developers
+Copyright=Copyright © 2015-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=task-list-symbolic

--- a/src/applets/tasklist/TasklistApplet.vala
+++ b/src/applets/tasklist/TasklistApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/tray/TrayApplet.plugin.in
+++ b/src/applets/tray/TrayApplet.plugin.in
@@ -3,6 +3,6 @@ Module=trayapplet.so
 Name=System Tray
 _Description=System Tray
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2015-2021 Budgie Desktop Developers
+Copyright=Copyright © 2015-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=system-tray-symbolic

--- a/src/applets/tray/TrayApplet.vala
+++ b/src/applets/tray/TrayApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/tray/carbontray/child.c
+++ b/src/applets/tray/carbontray/child.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2021 Budgie Desktop Developers
+ * Copyright © 2021-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/tray/carbontray/child.h
+++ b/src/applets/tray/carbontray/child.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2021 Budgie Desktop Developers
+ * Copyright © 2021-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/tray/carbontray/tray.c
+++ b/src/applets/tray/carbontray/tray.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2021 Budgie Desktop Developers
+ * Copyright © 2021-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/tray/carbontray/tray.h
+++ b/src/applets/tray/carbontray/tray.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2021 Budgie Desktop Developers
+ * Copyright © 2021-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/user-indicator/DBusInterfaces.vala
+++ b/src/applets/user-indicator/DBusInterfaces.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/user-indicator/UserIndicator.plugin.in
+++ b/src/applets/user-indicator/UserIndicator.plugin.in
@@ -3,6 +3,6 @@ Module=libuserindicator.so
 Name=User Indicator
 _Description=User Indicator
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2016-2021 Budgie Desktop Developers
+Copyright=Copyright © 2016-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=system-users-symbolic

--- a/src/applets/user-indicator/UserIndicator.vala
+++ b/src/applets/user-indicator/UserIndicator.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/user-indicator/UserIndicatorWindow.vala
+++ b/src/applets/user-indicator/UserIndicatorWindow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/workspaces/WindowIcon.vala
+++ b/src/applets/workspaces/WindowIcon.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2017-2021 Budgie Desktop Developers
+ * Copyright © 2017-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/workspaces/WorkspaceItem.vala
+++ b/src/applets/workspaces/WorkspaceItem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2017-2021 Budgie Desktop Developers
+ * Copyright © 2017-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/applets/workspaces/WorkspacesApplet.plugin.in
+++ b/src/applets/workspaces/WorkspacesApplet.plugin.in
@@ -3,6 +3,6 @@ Module=workspacesapplet.so
 Name=Workspace Switcher
 _Description=Workspace Switcher
 Authors=Budgie Desktop Developers
-Copyright=Copyright © 2017-2021 Budgie Desktop Developers
+Copyright=Copyright © 2017-2022 Budgie Desktop Developers
 Website=https://budgie-desktop.org
 Icon=workspace-switcher-symbolic

--- a/src/applets/workspaces/WorkspacesApplet.vala
+++ b/src/applets/workspaces/WorkspacesApplet.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2017-2021 Budgie Desktop Developers
+ * Copyright © 2017-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/appsys/AppSystem.vala
+++ b/src/appsys/AppSystem.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2014-2021 Budgie Desktop Developers
+ * Copyright © 2014-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/config/budgie-config.c
+++ b/src/config/budgie-config.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/config/budgie-config.h
+++ b/src/config/budgie-config.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/daemon/endsession.vala
+++ b/src/daemon/endsession.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/daemon/main.vala
+++ b/src/daemon/main.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2016-2021 Budgie Desktop Developers
+ * Copyright (C) 2016-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/daemon/manager.vala
+++ b/src/daemon/manager.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2016-2021 Budgie Desktop Developers
+ * Copyright © 2016-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/daemon/menus.vala
+++ b/src/daemon/menus.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2016-2021 Budgie Desktop Developers
+ * Copyright © 2016-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/daemon/osd.vala
+++ b/src/daemon/osd.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2016-2021 Budgie Desktop Developers
+ * Copyright © 2016-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/daemon/settings.vala
+++ b/src/daemon/settings.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2017-2021 Budgie Desktop Developers
+ * Copyright (C) 2017-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -1,8 +1,8 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright (C) 2017-2021 taaem <taaem@mailbox.org>
- * Copyright (C) 2017-2021 Budgie Desktop Developers
+ * Copyright (C) 2017-2022 taaem <taaem@mailbox.org>
+ * Copyright (C) 2017-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/lib/animation.vala
+++ b/src/lib/animation.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/lib/manager.vala
+++ b/src/lib/manager.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/lib/shadow.vala
+++ b/src/lib/shadow.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/lib/toplevel.vala
+++ b/src/lib/toplevel.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/libsession/libsession.vala
+++ b/src/libsession/libsession.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/panel/budgie-desktop-settings.vala
+++ b/src/panel/budgie-desktop-settings.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/main.vala
+++ b/src/panel/main.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_applet_chooser.vala
+++ b/src/panel/settings/settings_applet_chooser.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_autostart.vala
+++ b/src/panel/settings/settings_autostart.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2017-2021 Budgie Desktop Developers
+ * Copyright © 2017-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_desktop.vala
+++ b/src/panel/settings/settings_desktop.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_fonts.vala
+++ b/src/panel/settings/settings_fonts.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_item.vala
+++ b/src/panel/settings/settings_item.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_main.vala
+++ b/src/panel/settings/settings_main.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_page.vala
+++ b/src/panel/settings/settings_page.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_panel.vala
+++ b/src/panel/settings/settings_panel.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_panel_applets.vala
+++ b/src/panel/settings/settings_panel_applets.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_panel_dialogs.vala
+++ b/src/panel/settings/settings_panel_dialogs.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2017-2021 Budgie Desktop Developers
+ * Copyright © 2017-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_raven.vala
+++ b/src/panel/settings/settings_raven.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_style.vala
+++ b/src/panel/settings/settings_style.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/settings_wm.vala
+++ b/src/panel/settings/settings_wm.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/settings/themes.vala
+++ b/src/panel/settings/themes.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/panel/uuid.vala
+++ b/src/panel/uuid.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/applet-info.c
+++ b/src/plugin/applet-info.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/applet-info.h
+++ b/src/plugin/applet-info.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/applet.c
+++ b/src/plugin/applet.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/applet.h
+++ b/src/plugin/applet.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/plugin.c
+++ b/src/plugin/plugin.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/plugin.h
+++ b/src/plugin/plugin.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/popover-manager.c
+++ b/src/plugin/popover-manager.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/popover-manager.h
+++ b/src/plugin/popover-manager.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/popover.c
+++ b/src/plugin/popover.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2016-2021 Budgie Desktop Developers
+ * Copyright © 2016-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/popover.h
+++ b/src/plugin/popover.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2016-2021 Budgie Desktop Developers
+ * Copyright © 2016-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/plugin/util.h
+++ b/src/plugin/util.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2016-2021 Budgie Desktop Developers
+ * Copyright © 2016-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/polkit/polkitdialog.vala
+++ b/src/polkit/polkitdialog.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/app_sound_control.vala
+++ b/src/raven/app_sound_control.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/calendar.vala
+++ b/src/raven/calendar.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/headerwidget.vala
+++ b/src/raven/headerwidget.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/main_view.vala
+++ b/src/raven/main_view.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/mpris/MprisClient.vala
+++ b/src/raven/mpris/MprisClient.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/mpris/MprisGui.vala
+++ b/src/raven/mpris/MprisGui.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/mpris/MprisWidget.vala
+++ b/src/raven/mpris/MprisWidget.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/notification_clone.vala
+++ b/src/raven/notification_clone.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/notifications_group.vala
+++ b/src/raven/notifications_group.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  * Copyright 2014 Josh Klar <j@iv597.com> (original Budgie work, prior to Budgie 10)
  *
  * This program is free software; you can redistribute it and/or modify

--- a/src/raven/powerstrip.vala
+++ b/src/raven/powerstrip.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/sound.vala
+++ b/src/raven/sound.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/start_listening.vala
+++ b/src/raven/start_listening.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/raven/widget.vala
+++ b/src/raven/widget.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2018-2021 Budgie Desktop Developers
+ * Copyright © 2018-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/rundialog/RunDialog.vala
+++ b/src/rundialog/RunDialog.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/session/budgie-desktop.in
+++ b/src/session/budgie-desktop.in
@@ -4,7 +4,7 @@ BUDGIE_VERSION="@PACKAGE_VERSION@"
 
 if [ "$1" = "--version" ]; then
     echo "budgie-desktop $BUDGIE_VERSION"
-    echo "Copyright © 2014-2021 Budgie Desktop Developers"
+    echo "Copyright © 2014-2022 Budgie Desktop Developers"
     exit 0
 fi
 

--- a/src/theme/theme-manager.c
+++ b/src/theme/theme-manager.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2016-2021 Budgie Desktop Developers
+ * Copyright © 2016-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/theme/theme-manager.h
+++ b/src/theme/theme-manager.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2016-2021 Budgie Desktop Developers
+ * Copyright © 2016-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/theme/theme.c
+++ b/src/theme/theme.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/theme/theme.h
+++ b/src/theme/theme.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop.
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/wm/background.vala
+++ b/src/wm/background.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/wm/ibus.vala
+++ b/src/wm/ibus.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2016-2021 Budgie Desktop Developers
+ * Copyright © 2016-2022 Budgie Desktop Developers
  * Copyright (C) GNOME Shell Developers (Heavy inspiration, logic theft)
  *
  * This program is free software; you can redistribute it and/or modify

--- a/src/wm/keyboard.vala
+++ b/src/wm/keyboard.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  * Copyright (C) GNOME Shell Developers (Heavy inspiration, logic theft)
  *
  * This program is free software; you can redistribute it and/or modify

--- a/src/wm/main.vala
+++ b/src/wm/main.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/wm/shim.vala
+++ b/src/wm/shim.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -1,7 +1,7 @@
 /*
  * This file is part of budgie-desktop
  *
- * Copyright © 2015-2021 Budgie Desktop Developers
+ * Copyright © 2015-2022 Budgie Desktop Developers
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Description
where copyright was 2021 now updated to 2022.

Exception are the new carbon tray modules - changed to 2021-2022

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
