### PR TITLE
meson: Drop spurious 3rd positional argument to gnome.compile_resources

### DIFF
--- a/src/raven/meson.build
+++ b/src/raven/meson.build
@@ -6,7 +6,6 @@ gresource = join_paths(meson.current_source_dir(), 'ui', 'budgie-raven.gresource
 libraven_resources = gnome.compile_resources(
     'budgie-raven-resources',
     gresource,
-    'budgie-daemon.gresource.xml',
     source_dir: join_paths(meson.current_source_dir(), 'ui'),
     c_name: 'budgie_raven',
 )


### PR DESCRIPTION
This may become an error with some future meson version:

 src/raven/meson.build:6:0: ERROR: gnome.compile_resources takes exactly 2 arguments, but got 3.

See https://mesonbuild.com/Gnome-module.html#gnomecompile_resources
