### PR TITLE
Add initial support for horizontal / vertical tiling

### DIFF
--- a/src/daemon/endsession.vala
+++ b/src/daemon/endsession.vala
@@ -136,6 +136,8 @@ namespace Budgie {
 				this.cancel_clicked();
 				return Gdk.EVENT_STOP;
 			});
+
+			type_hint = Gdk.WindowTypeHint.DIALOG;
 		}
 
 		public void Open(uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) throws DBusError, IOError {

--- a/src/polkit/polkitdialog.vala
+++ b/src/polkit/polkitdialog.vala
@@ -72,7 +72,7 @@ namespace Budgie {
 
 		/* Save manually setting all this crap via some nice properties */
 		public AgentDialog(string action_id, string message, string icon_name, string cookie, Cancellable? cancellable) {
-			Object(action_id: action_id, message: message, auth_icon_name: icon_name, cookie: cookie, cancellable: cancellable);
+			Object(type_hint: Gdk.WindowTypeHint.DIALOG, action_id: action_id, message: message, auth_icon_name: icon_name, cookie: cookie, cancellable: cancellable);
 
 			set_keep_above(true);
 

--- a/src/rundialog/RunDialog.vala
+++ b/src/rundialog/RunDialog.vala
@@ -157,6 +157,8 @@ namespace Budgie {
 			});
 
 			setup_dbus.begin();
+
+			type_hint = Gdk.WindowTypeHint.DIALOG;
 		}
 
 		/**

--- a/src/wm/com.solus-project.budgie.wm.gschema.xml
+++ b/src/wm/com.solus-project.budgie.wm.gschema.xml
@@ -151,11 +151,11 @@
 			<summary>The binding to use to toggle Raven notifications</summary>
 			<description>The binding to use to toggle Raven notifications</description>
 		</key>
-		
+
 		<key type="as" name="toggle-layout">
 			<default><![CDATA[['<Super>T']]]></default>
-			<summary>The binding to use to toggle Raven notifications</summary>
-			<description>The binding to use to toggle Raven notifications</description>
+			<summary>The binding to use to toggle the layout between floating and horizontal tiling</summary>
+			<description>The binding to use to toggle the layout between floating and horizontal tiling</description>
 		</key>
 
 		<key name="button-layout" type="s">

--- a/src/wm/com.solus-project.budgie.wm.gschema.xml
+++ b/src/wm/com.solus-project.budgie.wm.gschema.xml
@@ -151,6 +151,12 @@
 			<summary>The binding to use to toggle Raven notifications</summary>
 			<description>The binding to use to toggle Raven notifications</description>
 		</key>
+		
+		<key type="as" name="toggle-layout">
+			<default><![CDATA[['<Super>T']]]></default>
+			<summary>The binding to use to toggle Raven notifications</summary>
+			<description>The binding to use to toggle Raven notifications</description>
+		</key>
 
 		<key name="button-layout" type="s">
 			<default>'appmenu:minimize,maximize,close'</default>

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -1170,9 +1170,13 @@ namespace Budgie {
 						strut_bottom = geom.height;
 					}
 				}
-				if (window.get_window_type() != Meta.WindowType.NORMAL && window.get_window_type() != Meta.WindowType.UTILITY) {
+				if ((window.get_window_type() != Meta.WindowType.NORMAL && window.get_window_type() != Meta.WindowType.UTILITY) || window.minimized) {
 					++irrev_len;
 					continue;
+				}
+				if (window.maximized_horizontally || window.maximized_vertically) {
+					window.unmaximize(Meta.MaximizeFlags.HORIZONTAL);
+					window.unmaximize(Meta.MaximizeFlags.VERTICAL);
 				}
 			}
 			uint win_i = 0;

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -9,7 +9,7 @@
  * (at your option) any later version.
  */
 
- namespace Budgie {
+namespace Budgie {
 	public const string MUTTER_EDGE_TILING = "edge-tiling";
 	public const string MUTTER_MODAL_ATTACH = "attach-modal-dialogs";
 	public const string MUTTER_BUTTON_LAYOUT = "button-layout";

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -1149,7 +1149,7 @@ namespace Budgie {
 			switcher_proxy.ShowSwitcher.begin(curr_xid);
 		}
 
-		private void tile_windows() { // horizontally
+		private void tile_windows() {
 			var workspace = get_display().get_workspace_manager().get_active_workspace();
 			if (workspace == null) return;
 			var win_list = workspace.list_windows();
@@ -1157,6 +1157,13 @@ namespace Budgie {
 			Gdk.Monitor mon = screen.get_display().get_primary_monitor();
 			if (mon == null) return;
 			Gdk.Rectangle rect = mon.get_geometry();
+			switch (layout) {
+				case Layout.FLOATING: return;
+				case Layout.TILING_HORIZ: tile_windows_horiz(rect, win_list); break;
+				// case Layout.TILING_VERT: tile_windows_vert();
+			}
+		}
+		private void tile_windows_horiz(Gdk.Rectangle screen_size, List<weak Meta.Window> win_list) {
 			int irrev_len = 0;
 			int strut_top = 0, strut_bottom = 0;
 			foreach (var window in win_list) {
@@ -1186,9 +1193,9 @@ namespace Budgie {
 					continue;
 				}
 				window.move_resize_frame(false, 0, 
-					((int)((rect.height)/ (int)(win_list.length() - irrev_len))*(int)win_i), rect.width, 
-					(int)((rect.height) / (int)(win_list.length() - irrev_len)) - (win_i ==0 ? strut_top : 0)
-					- (win_i ==( win_list.length() - irrev_len - 1) ? strut_bottom:0));
+					((int)((screen_size.height)/ (int)(win_list.length() - irrev_len))*(int)win_i), screen_size.width, 
+					(int)((screen_size.height) / (int)(win_list.length() - irrev_len)) - (win_i == 0 ? strut_top : 0)
+					- (win_i == (win_list.length() - irrev_len - 1) ? strut_bottom : 0));
 				++win_i;
 			}
 		}

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -1158,15 +1158,15 @@ namespace Budgie {
 			if (mon == null) return;
 			Gdk.Rectangle rect = mon.get_geometry();
 			int irrev_len = 0;
-			int strut_top = 0, strut_bottom = 0, strut_left = 0, strut_right = 0;
+			int strut_top = 0, strut_bottom = 0;
 			foreach (var window in win_list) {
 				if (window == null) continue;
 				if (window.get_window_type() == Meta.WindowType.DOCK) {
 					var geom = window.get_frame_rect();
 					assert(geom.y >= 0);
-					if (geom.y == 0) {
+					if (geom.y == 0 && geom.width > geom.height) {
 						strut_top = geom.height;
-					} else {
+					} else if (geom.y > 0 && geom.height > geom.width) { // fairly reasonable checks
 						strut_bottom = geom.height;
 					}
 				}


### PR DESCRIPTION
## Description
This PR adds basic support for horizontal tiling to Budgie. It looks like this:
![image](https://user-images.githubusercontent.com/48339289/148104996-8c78e729-bc32-4718-a5ae-fe4366517818.png)
We add a new option to the dconf schema com.solus-project.budgie.wm.gschema.xml: toggle-layout, which is the keybinding to toggle layout. Currently the default is `<Super>T`. 

In the future support will be added for vertical tiling in a follow-up PR if this one gets accepted. 

The only downside here is that size hints are respected, which is great for a floating WM but not so great for a tiling one (obviously not what Mutter developers had in mind). If anyone knows any way to override size hints beyond using manual X11 calls or simply removing the size hints, please let me know. For now I've just used move_resize_frame, which respects hints, but it's not that horrible.

I'm new to Mutter, Budgie, and Vala, so please tell me if there's any improvements I can make! Code reviews and some testing would be much appreciated.

Also as for multi-monitor support, in the future this needs to be more discussed. Right now it uses the primary monitor reported by gdk, whatever that is, and tiles all windows on just that monitor.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
