### PR TITLE
Don't use the notification settings for DND

### DIFF
--- a/src/applets/notifications/NotificationsApplet.vala
+++ b/src/applets/notifications/NotificationsApplet.vala
@@ -19,11 +19,11 @@ private const string ALERT_SYMBOLIC = "notification-alert-symbolic";
 private const string DND_SYMBOLIC = "notification-disabled-symbolic";
 public const string RAVEN_DBUS_NAME = "org.budgie_desktop.Raven";
 public const string RAVEN_DBUS_OBJECT_PATH = "/org/budgie_desktop/Raven";
+public const string NOTIFICATION_DBUS_NAME = "org.budgie_desktop.Notifications";
+public const string NOTIFICATION_DBUS_OBJECT_PATH = "/org/budgie_desktop/Notifications";
 
 [DBus (name="org.budgie_desktop.Raven")]
 public interface RavenRemote : GLib.Object {
-	public signal void DoNotDisturbChanged(bool active);
-	public abstract async bool GetDoNotDisturbState() throws Error;
 	public abstract async void ToggleNotificationsView() throws Error;
 	public signal void NotificationsChanged();
 	public abstract async uint GetNotificationCount() throws Error;
@@ -31,11 +31,17 @@ public interface RavenRemote : GLib.Object {
 	public signal void ReadNotifications();
 }
 
+[DBus (name="org.buddiesofbudgie.budgie.Dispatcher")]
+public interface DispatcherRemote : GLib.Object {
+	public signal void DoNotDisturbChanged(bool value);
+}
+
 public class NotificationsApplet : Budgie.Applet {
 	Gtk.EventBox? widget;
 	Gtk.Image? icon;
 	Gdk.Pixbuf? dnd_pixbuf = null;
 	RavenRemote? raven_proxy = null;
+	DispatcherRemote? dispatcher = null;
 
 	public NotificationsApplet() {
 		widget = new Gtk.EventBox();
@@ -48,6 +54,7 @@ public class NotificationsApplet : Budgie.Applet {
 		icon.valign = Gtk.Align.CENTER;
 
 		Bus.get_proxy.begin<RavenRemote>(BusType.SESSION, RAVEN_DBUS_NAME, RAVEN_DBUS_OBJECT_PATH, 0, null, on_raven_get);
+		Bus.get_proxy.begin<DispatcherRemote>(BusType.SESSION, NOTIFICATION_DBUS_NAME, NOTIFICATION_DBUS_OBJECT_PATH, 0, null, on_dispatcher_get);
 
 		widget.button_release_event.connect(on_button_release);
 
@@ -69,14 +76,22 @@ public class NotificationsApplet : Budgie.Applet {
 	void on_raven_get(Object? o, AsyncResult? res) {
 		try {
 			raven_proxy = Bus.get_proxy.end(res);
-			raven_proxy.DoNotDisturbChanged.connect(on_dnd_changed);
 			raven_proxy.NotificationsChanged.connect(on_notifications_changed);
 			raven_proxy.UnreadNotifications.connect(on_notifications_unread);
 			raven_proxy.ReadNotifications.connect(on_notifications_read);
 			raven_proxy.GetNotificationCount.begin(on_get_count);
-			raven_proxy.GetDoNotDisturbState.begin(on_get_dnd_state);
 		} catch (Error e) {
 			warning("Failed to gain Raven proxy: %s", e.message);
+		}
+	}
+
+	/* Hold onto our notification proxy ref */
+	void on_dispatcher_get(Object? o, AsyncResult? res) {
+		try {
+			this.dispatcher = Bus.get_proxy.end(res);
+			this.dispatcher.DoNotDisturbChanged.connect(on_dnd_changed);
+		} catch (Error e) {
+			warning("Failed to get notification dispatcher proxy: %s", e.message);
 		}
 	}
 
@@ -109,19 +124,6 @@ public class NotificationsApplet : Budgie.Applet {
 		} else {
 			this.icon.set_tooltip_text(_("No unread notifications"));
 		}
-	}
-
-	void on_get_dnd_state(Object? o, AsyncResult? res) {
-		bool active = true; // Default to true
-
-		try {
-			active = raven_proxy.GetDoNotDisturbState.end(res);
-		} catch (Error e) {
-			warning("Failed to get Do Not Disturb state: %s", e.message);
-			return;
-		}
-
-		set_dnd_state(active); // Set the DND state
 	}
 
 	void set_dnd_state(bool enabled) {

--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -146,8 +146,7 @@ namespace Budgie {
 				this.dispatcher.NotificationClosed.connect(on_notification_closed);
 
 				this.do_not_disturb = this.dispatcher.get_do_not_disturb();
-				var image = this.do_not_disturb ? image_notifications_disabled : image_notifications_enabled;
-				this.button_mute.set_image(image);
+				this.button_mute.set_image(this.do_not_disturb ? image_notifications_disabled : image_notifications_enabled);
 			} catch (Error e) {
 				critical("Unable to connect to notifications dispatcher: %s", e.message);
 			}

--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -58,11 +58,13 @@ namespace Budgie {
 		);
 
 		public signal void NotificationClosed(uint32 id, string app_name, NotificationCloseReason reason);
+
+		public abstract bool get_do_not_disturb() throws DBusError, IOError;
+		public abstract void toggle_do_not_disturb() throws DBusError, IOError;
 	}
 
 	public class NotificationsView : Gtk.Box {
 		private const string BUDGIE_PANEL_SCHEMA = "com.solus-project.budgie-panel";
-		private const string NOTIFICATION_SCHEMA = "org.gnome.desktop.notifications";
 		private const string APPLICATION_SCHEMA = "org.gnome.desktop.notifications.application";
 		private const string APPLICATION_PREFIX = "/org/gnome/desktop/notifications/application";
 
@@ -73,17 +75,16 @@ namespace Budgie {
 		private Gtk.Image image_notifications_disabled = new Gtk.Image.from_icon_name("notification-disabled-symbolic", Gtk.IconSize.MENU);
 		private Gtk.Image image_notifications_enabled = new Gtk.Image.from_icon_name("notification-alert-symbolic", Gtk.IconSize.MENU);
 
+		private bool do_not_disturb { get; private set; default = false; }
 		private bool performing_clear_all { get; private set; default = false; }
 
 		private Dispatcher dispatcher { private get; private set; default = null; }
 		private HashTable<uint32, Budgie.Notification> notifications { private get; private set; default = null; }
 		private HashTable<string, NotificationGroup> notification_groups { private get; private set; default = null; }
 		private Settings budgie_settings { private get; private set; default = null; }
-		private Settings notification_settings { private get; private set; default = null; }
 
 		construct {
 			this.budgie_settings = new Settings(BUDGIE_PANEL_SCHEMA);
-			this.notification_settings = new Settings(NOTIFICATION_SCHEMA);
 
 			this.orientation = Gtk.Orientation.VERTICAL;
 			this.spacing = 0;
@@ -95,8 +96,6 @@ namespace Budgie {
 			clear_notifications_button.get_style_context().add_class("clear-all-notifications");
 
 			button_mute = new Gtk.Button();
-			var image = notification_settings.get_boolean("show-banners") ? image_notifications_enabled : image_notifications_disabled;
-			button_mute.set_image(image);
 			button_mute.relief = Gtk.ReliefStyle.NONE;
 			button_mute.get_style_context().add_class("do-not-disturb");
 
@@ -145,6 +144,10 @@ namespace Budgie {
 				this.dispatcher = Bus.get_proxy.end(res);
 				this.dispatcher.NotificationAdded.connect(on_notification_added);
 				this.dispatcher.NotificationClosed.connect(on_notification_closed);
+
+				this.do_not_disturb = this.dispatcher.get_do_not_disturb();
+				var image = this.do_not_disturb ? image_notifications_disabled : image_notifications_enabled;
+				this.button_mute.set_image(image);
 			} catch (Error e) {
 				critical("Unable to connect to notifications dispatcher: %s", e.message);
 			}
@@ -189,8 +192,8 @@ namespace Budgie {
 
 			// If popups aren't being shown, immediately call our close function to put
 			// the notification in Raven.
-			bool no_popup = this.dispatcher.notifications_paused ||
-							!this.notification_settings.get_boolean("show-banners") ||
+			bool no_popup = this.do_not_disturb ||
+							this.dispatcher.notifications_paused ||
 							!application_settings.get_boolean("show-banners");
 
 			if (no_popup) {
@@ -313,10 +316,14 @@ namespace Budgie {
 		}
 
 		void do_not_disturb_toggle() {
-			var current = this.notification_settings.get_boolean("show-banners");
-			this.notification_settings.set_boolean("show-banners", !current);
-			button_mute.set_image(!current ? image_notifications_enabled : image_notifications_disabled);
-			Raven.get_instance().set_dnd_state(current);
+			this.do_not_disturb = !this.do_not_disturb;
+			this.button_mute.set_image(!this.do_not_disturb ? image_notifications_enabled : image_notifications_disabled);
+
+			try {
+				this.dispatcher.toggle_do_not_disturb();
+			} catch (Error e) {
+				warning("Unable to toggle Do Not Disturb: %s", e.message);
+			}
 		}
 	}
 }

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -43,8 +43,6 @@ namespace Budgie {
 	[DBus (name="org.budgie_desktop.Raven")]
 	public class RavenIface {
 		private Raven? parent = null;
-		[DBus (visible=false)]
-		private bool dnd_enabled = false;
 
 		[DBus (visible=false)]
 		public uint notifications = 0;
@@ -141,29 +139,6 @@ namespace Budgie {
 
 		public string get_version() throws DBusError, IOError {
 			return "1";
-		}
-
-		/**
-		* Do Not Disturb Functionality
-		*/
-		public signal void DoNotDisturbChanged(bool active);
-
-		public bool GetDoNotDisturbState() throws DBusError, IOError {
-			return this.dnd_enabled;
-		}
-
-		public void SetDoNotDisturb(bool enable) throws DBusError, IOError {
-			this.dnd_enabled = enable;
-			this.DoNotDisturbChanged(this.dnd_enabled);
-		}
-
-		/**
-		* Notification pausing on fullscreen functionality
-		*/
-		public signal void PauseNotificationsChanged(bool paused);
-
-		public void SetPauseNotifications(bool paused) throws DBusError, IOError {
-			PauseNotificationsChanged(paused);
 		}
 	}
 
@@ -265,14 +240,6 @@ namespace Budgie {
 
 		public static unowned Raven? get_instance() {
 			return Raven._instance;
-		}
-
-		public void set_dnd_state(bool active) {
-			try {
-				this.iface.SetDoNotDisturb(active); // Set the active state of our RavenIFace DND
-			} catch (Error e) {
-				warning("Error in Raven | Failed to set Do Not Disturb state: %s", e.message);
-			}
 		}
 
 		public void set_notification_count(uint count) {


### PR DESCRIPTION
## Description
This removes our dependence on GNOME settings schemas for Do Not Disturb functionality (again). I decided to make this a PR to get other eyes on it in case there's something I missed.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
