### PR TITLE
Add keywords to budgie-desktop-settings.desktop

### DIFF
--- a/src/panel/budgie-desktop-settings.desktop.in
+++ b/src/panel/budgie-desktop-settings.desktop.in
@@ -9,3 +9,4 @@ Type=Application
 Categories=GNOME;GTK;System;
 OnlyShowIn=Budgie;
 StartupWMClass=budgie-desktop-settings
+Keywords=Preferences;Settings;


### PR DESCRIPTION
## Description
Please refer to
 https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html,
 Bug#693918, and
 https://wiki.gnome.org/Initiatives/GnomeGoals/DesktopFileKeywords for details.

This resolve reported lintian issues in Debian packaging.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
