### PR TITLE
Ensure gschema override for switch-input-source* is formatted correctly.

### DIFF
--- a/src/wm/20_solus-project.budgie.wm.gschema.override
+++ b/src/wm/20_solus-project.budgie.wm.gschema.override
@@ -12,5 +12,5 @@ button-layout = 'appmenu:minimize,maximize,close'
 picture-uri = 'file:///usr/share/backgrounds/budgie/default.jpg'
 
 [org.gnome.desktop.wm.keybindings:Budgie]
-switch-input-source = '[\'<Alt>Shift_L\', \'<Super>space\', \'XF86Keyboard\']'
-switch-input-source-backward = '[\'<Super><Shift>space\', \'<Shift>XF86Keyboard\']'
+switch-input-source = ['<Alt>Shift_L', '<Super>space', 'XF86Keyboard']
+switch-input-source-backward = ['<Super><Shift>space', '<Shift>XF86Keyboard']


### PR DESCRIPTION
## Description
ubuntu 22.04:

compiling gschema produces the following error:
```
Error parsing key “switch-input-source” in schema “org.gnome.desktop.wm.keybindings:Budgie” as specified in override file “/usr/share/glib-2.0/schemas/20_solus-project.budgie.wm.gschema.override”: 0-56:can not parse as value of type 'as'. Ignoring override for this key.
Error parsing key “switch-input-source-backward” in schema “org.gnome.desktop.wm.keybindings:Budgie” as specified in override file “/usr/share/glib-2.0/schemas/20_solus-project.budgie.wm.gschema.override”: 0-52:can not parse as value of type 'as'. Ignoring override for this key.
```

This means that our switch-input overrides are ignored and the default GNOME overrides are used instead.

Verified that glib-compile-schema no longer errors and dconf-editor shows that the overrides we have specified are displayed for these keys.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
