### PR TITLE
Fix some applications showing their own notification popups when paused

### DIFF
--- a/src/daemon/notifications/dbus.vala
+++ b/src/daemon/notifications/dbus.vala
@@ -198,22 +198,6 @@
 			var id = (replaces_id != 0 ? replaces_id : ++notif_id);
 			var notification = new Notification(id, app_name, app_icon, summary, body, actions, hints, expire_timeout);
 
-			// Check for DoNotDisturb
-			var should_notify = !this.dispatcher.get_do_not_disturb() || notification.urgency == NotificationUrgency.CRITICAL;
-			if (!should_notify) {
-				this.dispatcher.NotificationAdded(
-					app_name,
-					id,
-					app_icon,
-					summary,
-					body,
-					actions,
-					hints,
-					expire_timeout
-				);
-				return id;
-			}
-
 			string settings_app_name = app_name;
 			bool should_show = true; // Default to showing notification
 
@@ -230,23 +214,17 @@
 				"%s/%s/".printf(APPLICATION_PREFIX, settings_app_name)
 			);
 
+			var should_notify = !this.dispatcher.get_do_not_disturb() || notification.urgency == NotificationUrgency.CRITICAL;
 			should_show = app_notification_settings.get_boolean("enable") &&
 							app_notification_settings.get_boolean("show-banners") &&
 							!this.dispatcher.notifications_paused;
 
-			// Early return if we're not showing a popup
-			if (!should_show) {
-				this.dispatcher.NotificationAdded(
-					app_name,
-					id,
-					app_icon,
-					summary,
-					body,
-					actions,
-					hints,
-					expire_timeout
-				);
-				return id;
+			// Set to expire immediately if a popup shouldn't be shown.
+			// This prevents some applications, e.g. Firefox, from showing
+			// its own notification when Budgie notifications are paused for
+			// any reason.
+			if (!should_notify || !should_show) {
+				notification.expire_timeout = 0;
 			}
 
 			// Add a new notification popup if we should show one
@@ -258,7 +236,7 @@
 				this.configure_window(this.popups[id]);
 				this.latest_popup_id = id;
 				this.popups[id].show_all();
-				this.popups[id].begin_decay(expire_timeout);
+				this.popups[id].begin_decay(notification.expire_timeout);
 
 				this.popups[id].ActionInvoked.connect((action_key) => {
 					this.ActionInvoked(id, action_key);

--- a/src/daemon/notifications/popup.vala
+++ b/src/daemon/notifications/popup.vala
@@ -80,7 +80,7 @@ namespace Budgie.Notifications {
 			}
 
 			var t = timeout;
-			if (timeout < MIN_TIMEOUT) {
+			if (timeout < MIN_TIMEOUT && timeout != 0) {
 				t = MIN_TIMEOUT;
 			} else if (timeout > MAX_TIMEOUT) {
 				t = MAX_TIMEOUT;

--- a/src/lib/notification.vala
+++ b/src/lib/notification.vala
@@ -61,7 +61,7 @@
 		public string app_icon { get; construct; }
 		public string body { get; construct set; }
 		public string summary { get; construct set; }
-		public uint expire_timeout { get; construct; }
+		public uint expire_timeout { get; construct set; }
 
 		public string category { get; construct set; }
 		public int64 timestamp { get; construct set; }


### PR DESCRIPTION
## Description
Before this commit, Firefox would show its own notification popups whenever Budgie notifications or popups were paused or disabled. This seems to fix that issue: when notifications are paused, no popups of any kind are shown.

I have no idea why this matters to Firefox, nor how it even detects it, but so far it seems to be working.

This also matches what the Budgie notification server used to do before the rewrite. Previously the expiry variable was set to 0 and all was right with the world.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
