### PR TITLE
Fix notification mute button sometimes starting without an image

### DIFF
--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -100,6 +100,7 @@ namespace Budgie {
 			button_mute.relief = Gtk.ReliefStyle.NONE;
 			button_mute.valign = Gtk.Align.CENTER;
 			button_mute.get_style_context().add_class("do-not-disturb");
+			button_mute.set_image(image_notifications_enabled); // Ensure we start with an icon
 
 			var control_buttons = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
 			control_buttons.pack_start(button_mute, false, false, 0);


### PR DESCRIPTION
## Description
Since the notifications rewrite, the button to trigger Do Not Disturb would sometimes not be shown.

This ensures that it always starts with an icon, and is thus shown.


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
