### PR TITLE
Actually fix notification pausing sometimes breaking Firefox notifica…

### DIFF
--- a/src/daemon/notifications/dbus.vala
+++ b/src/daemon/notifications/dbus.vala
@@ -220,9 +220,6 @@
 							!this.dispatcher.notifications_paused;
 
 			// Set to expire immediately if a popup shouldn't be shown.
-			// This prevents some applications, e.g. Firefox, from showing
-			// its own notification when Budgie notifications are paused for
-			// any reason.
 			if (!should_notify || !should_show) {
 				notification.expire_timeout = 0;
 			}
@@ -271,16 +268,17 @@
 		 * or to cancel a notification with no expiration time.
 		 *
 		 * Per the spec, a blank DBusError should be thrown if the notification doesn't exist when this is called.
+		 * However, this can break notifications from some applications, and other desktop environments don't
+		 * follow that part of the spec, either. So, return to avoid breaking things.
 		 */
 		public void CloseNotification(uint32 id) throws DBusError, IOError {
-			if (this.popups.contains(id)) {
-				this.popups[id].dismiss();
-				this.popups.remove(id);
-				this.NotificationClosed(id, NotificationCloseReason.CLOSED);
+			if (!this.popups.contains(id)) {
 				return;
 			}
 
-			throw new DBusError.FAILED("");
+			this.popups[id].dismiss();
+			this.popups.remove(id);
+			this.NotificationClosed(id, NotificationCloseReason.CLOSED);
 		}
 
 		/**


### PR DESCRIPTION
This time without me messing up entirely with Git.

## Description
This fixes (for real this time) notifications from Firefox not using the system notification implementation when notifications are paused. The issue occurred because per the spec, an empty DBus error with no message should be returned when an application attempts to close a notification, but no notification can be found. Firefox tries to close the notifications it generates, and because there are no notification popups stored, we would send the DBus error. This causes Firefox to stop using the system notification system for the rest of the browser session.

Before the rewrite, Budgie did not send the DBus error, and gnome-shell currently doesn't, either. So, just return instead of sending an error and potentially breaking notifications.

Tested with multiple long periods of having notifications paused over the last day and a half, and Firefox notifications continuing to function as expected.

Thanks to the folks at the Firefox developers Matrix for assisting in finding the cause and helping me look at the Firefox code around notifications!


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
