### PR TITLE
Fix SEGV when input source was switched by Alt+Shift_L

### DIFF
--- a/src/wm/keyboard.vala
+++ b/src/wm/keyboard.vala
@@ -61,7 +61,7 @@ namespace Budgie {
 		string[] options = {};
 
 		Settings? settings = null;
-		Array<InputSource> sources;
+		Array<InputSource> sources = null;
 		InputSource fallback;
 
 		uint current_source = 0;
@@ -102,6 +102,9 @@ namespace Budgie {
 		void switch_input_source(Meta.Display display,
 								Meta.Window? window, Clutter.KeyEvent? event,
 								Meta.KeyBinding binding) {
+			if (sources == null || sources.length == 0) {
+				return;
+			}
 			current_source = (current_source+1) % sources.length;
 			this.hold_keyboard();
 			this.apply_layout(current_source);
@@ -111,6 +114,9 @@ namespace Budgie {
 		void switch_input_source_backward(Meta.Display display,
 										Meta.Window? window, Clutter.KeyEvent? event,
 										Meta.KeyBinding binding) {
+			if (sources == null || sources.length == 0) {
+				return;
+			}
 			current_source = (current_source-1) % sources.length;
 			this.hold_keyboard();
 			this.apply_layout(current_source);


### PR DESCRIPTION
## Description

Closes: #56

When budgie-wm is used with non ibus input method,
It causes a SEGV unexpectedly.

There are two vectors to cause this situation.

* Array<InputSource> is not initialized explicitly, but it may be
  accessed unexpectedly.
* Array<InputSource> may be empty, thus it causes arithmetic exception
 with "% sources.length"

## Steps to reproduce

* Use non ibus input method (e.g. fcitx5)
* Type Alt+Shift_L twice or so

PR fixes the issue on Debian unstable with budgie-desktop_10.5.3+git20220217a-1 (with this patch)

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
