### PR TITLE
Update tab switcher style for built-in theme

### DIFF
--- a/src/theme/3.20/_main.scss
+++ b/src/theme/3.20/_main.scss
@@ -112,8 +112,21 @@
 .budgie-switcher-window {
     @extend .budgie-notification-window;
 
+    > decoration {
+        box-shadow: 0 2px 4px $panel_bg;
+        border-radius: 8px;
+    }
+
+    > box {
+        padding: 6px;
+        border-radius: 8px;
+    }
+
     // Flowbox
-    flowbox { color: $fg_color; }
+    flowbox {
+        color: $fg_color;
+        padding: 4px;
+    }
     flowboxchild {
         @include budgie_switcher_child(disabled, label);
     }

--- a/src/theme/common/_switcher.scss
+++ b/src/theme/common/_switcher.scss
@@ -1,21 +1,12 @@
 // Alt+tab switcher in Budgie
 @mixin budgie_switcher_child($insensitive, $label) {
-    padding: 3px;
+    padding: 4px;
     color: $fg_color;
+    border-radius: 3px;
+    transition: background-color 75ms ease-out;
 
-    &:hover { background-color: $button_bg; }
-    &:active { color: $fg_color; }
-    &:selected {
-        color: $selected_fg_color;
-        background-color: $selected_bg_color;
-
-        &:active { color: $selected_fg_color; }
-        &:hover { background-color: mix(black, $selected_bg_color, 10%); }
-        &:#{$insensitive} {
-            color: transparentize($selected_fg_color, 0.3);
-            background-color: transparentize($selected_bg_color, 0.3);
-            #{$label} { color: inherit; }
-        }
+    &:hover, &:active, &:selected {
+        background-color: transparentize($fg_color, 0.84);
     }
 }
 


### PR DESCRIPTION
## Description

Restyles the tab switcher (alt-tab) in the built-in theme to fit with the rest of the dialogs.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/12981608/155603614-3170b8d6-17ba-481b-b06a-2e87417c6cb7.png)


### After

![image](https://user-images.githubusercontent.com/12981608/155603460-d1ee4fd2-ba74-4288-b6cc-ac2f641e5e46.png)

