### PR TITLE
Implement fractional scaling for icon-tasklist icons

### DIFF
--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -461,7 +461,10 @@ public class IconTasklistApplet : Budgie.Applet {
 	 * Our panel has changed size, record the new icon sizes
 	 */
 	public override void panel_size_changed(int panel, int icon, int small_icon) {
-		this.desktop_helper.icon_size = small_icon;
+		// equals 24px icons on a 36px panel
+		int target_size = (int) Math.round((2.0 / 3.0) * panel);
+
+		this.desktop_helper.icon_size = target_size;
 		this.desktop_helper.panel_size = panel;
 		this.set_icons_size();
 	}


### PR DESCRIPTION
## Description

This commit allows icons in Icon Tasklist to scale to any arbitrary panel size. The scaling factor implemented is 2/3 of the panel size, which gives 24px icons at a 36px panel size (the same as the current default).

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
