### PR TITLE
Proper icon tasklist scaling

### DIFF
--- a/src/applets/icon-tasklist/IconButton.vala
+++ b/src/applets/icon-tasklist/IconButton.vala
@@ -428,8 +428,8 @@ public class IconButton : Gtk.ToggleButton {
 		if (app_icon != null) {
 			this.icon.set_from_gicon(app_icon, Gtk.IconSize.INVALID);
 		} else if (pixbuf_icon != null) {
-			// scale pixbuf if it doesn't match the size we want
-			if (pixbuf_icon.width != target_icon_size || pixbuf_icon.height != target_icon_size) {
+			// scale pixbuf if it doesn't match the size we want AND if the size we want is valid
+			if (target_icon_size > 0 && (pixbuf_icon.width != target_icon_size || pixbuf_icon.height != target_icon_size)) {
 				pixbuf_icon = pixbuf_icon.scale_simple(target_icon_size, target_icon_size, Gdk.InterpType.BILINEAR);
 			}
 			this.icon.set_from_pixbuf(pixbuf_icon);

--- a/src/applets/icon-tasklist/IconButton.vala
+++ b/src/applets/icon-tasklist/IconButton.vala
@@ -14,6 +14,10 @@ const int INDICATOR_SIZE = 2;
 const int INDICATOR_SPACING = 1;
 const int INACTIVE_INDICATOR_SPACING = 2;
 
+const int TARGET_ICON_PADDING = 18;
+const double TARGET_ICON_SCALE = 2.0 / 3.0;
+const int FORMULA_SWAP_POINT = TARGET_ICON_PADDING * 3;
+
 /**
  * IconButton provides the pretty IconTasklist button to house one or more
  * windows in a group, as well as selection capabilities, interaction, animations
@@ -63,8 +67,6 @@ public class IconButton : Gtk.ToggleButton {
 		this.originally_pinned = pinned;
 		this.gobject_constructors_suck();
 		this.create_popover(); // Create our popover
-
-		this.update_icon();
 
 		if (this.has_valid_windows(null)) {
 			this.get_style_context().add_class("running");
@@ -830,10 +832,10 @@ public class IconButton : Gtk.ToggleButton {
 		if (should_update_icon) {
 			int max = (int) Math.fmin(definite_allocation.width, definite_allocation.height);
 
-			if (max > 36) {
-				this.target_icon_size = max - 12;
+			if (max > FORMULA_SWAP_POINT) {
+				this.target_icon_size = max - TARGET_ICON_PADDING;
 			} else {
-				this.target_icon_size = (int) Math.round((2.0 / 3.0) * max);
+				this.target_icon_size = (int) Math.round(TARGET_ICON_SCALE * max);
 			}
 
 			update_icon();

--- a/src/applets/icon-tasklist/IconButton.vala
+++ b/src/applets/icon-tasklist/IconButton.vala
@@ -68,6 +68,8 @@ public class IconButton : Gtk.ToggleButton {
 		this.gobject_constructors_suck();
 		this.create_popover(); // Create our popover
 
+		this.target_icon_size = helper.panel_size;
+
 		if (this.has_valid_windows(null)) {
 			this.get_style_context().add_class("running");
 		}
@@ -808,7 +810,17 @@ public class IconButton : Gtk.ToggleButton {
 	}
 
 	protected void on_size_allocate(Gtk.Allocation allocation) {
-		var should_update_icon = definite_allocation != allocation;
+		if (definite_allocation != allocation) {
+			int max = (int) Math.fmin(allocation.width, allocation.height);
+
+			if (max > FORMULA_SWAP_POINT) {
+				this.target_icon_size = max - TARGET_ICON_PADDING;
+			} else {
+				this.target_icon_size = (int) Math.round(TARGET_ICON_SCALE * max);
+			}
+
+			update_icon();
+		}
 
 		this.definite_allocation = allocation;
 		base.size_allocate(definite_allocation);
@@ -827,18 +839,6 @@ public class IconButton : Gtk.ToggleButton {
 			}
 		} else if (this.window != null) {
 			this.window.set_icon_geometry(x, y, this.definite_allocation.width, this.definite_allocation.height);
-		}
-
-		if (should_update_icon) {
-			int max = (int) Math.fmin(definite_allocation.width, definite_allocation.height);
-
-			if (max > FORMULA_SWAP_POINT) {
-				this.target_icon_size = max - TARGET_ICON_PADDING;
-			} else {
-				this.target_icon_size = (int) Math.round(TARGET_ICON_SCALE * max);
-			}
-
-			update_icon();
 		}
 	}
 

--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -438,7 +438,7 @@ public class IconTasklistApplet : Budgie.Applet {
 		this.desktop_helper.panel_position = position;
 		this.desktop_helper.orientation = this.get_orientation();
 		this.main_layout.set_orientation(this.desktop_helper.orientation);
-		resize_buttons();
+		resize();
 	}
 
 	/**
@@ -447,15 +447,17 @@ public class IconTasklistApplet : Budgie.Applet {
 	public override void panel_size_changed(int panel, int icon, int small_icon) {
 		this.desktop_helper.icon_size = small_icon;
 		this.desktop_helper.panel_size = panel;
-		resize_buttons();
+		resize();
 	}
 
-	private void resize_buttons() {
+	private void resize() {
 		Wnck.set_default_icon_size(this.desktop_helper.panel_size);
 
 		this.buttons.foreach((id, button) => {
 			button.queue_resize();
 		});
+
+		queue_resize();
 	}
 
 	public override void update_popovers(Budgie.PopoverManager? manager) {

--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -431,21 +431,6 @@ public class IconTasklistApplet : Budgie.Applet {
 		}
 	}
 
-
-	private void set_icons_size() {
-		Wnck.set_default_icon_size(this.desktop_helper.icon_size);
-
-		Idle.add(() => {
-			this.buttons.foreach((id, button) => {
-				button.update_icon();
-			});
-			return false;
-		});
-
-		this.queue_resize();
-		this.queue_draw();
-	}
-
 	/**
 	 * Our panel has moved somewhere, stash the positions
 	 */
@@ -453,8 +438,7 @@ public class IconTasklistApplet : Budgie.Applet {
 		this.desktop_helper.panel_position = position;
 		this.desktop_helper.orientation = this.get_orientation();
 		this.main_layout.set_orientation(this.desktop_helper.orientation);
-
-		this.set_icons_size();
+		resize_buttons();
 	}
 
 	/**
@@ -463,7 +447,18 @@ public class IconTasklistApplet : Budgie.Applet {
 	public override void panel_size_changed(int panel, int icon, int small_icon) {
 		this.desktop_helper.icon_size = small_icon;
 		this.desktop_helper.panel_size = panel;
-		this.set_icons_size();
+		resize_buttons();
+	}
+
+	private void resize_buttons() {
+		Wnck.set_default_icon_size(this.desktop_helper.panel_size);
+
+		Idle.add(() => {
+			this.buttons.foreach((id, button) => {
+				button.queue_resize();
+			});
+			return false;
+		});
 	}
 
 	public override void update_popovers(Budgie.PopoverManager? manager) {

--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -453,11 +453,8 @@ public class IconTasklistApplet : Budgie.Applet {
 	private void resize_buttons() {
 		Wnck.set_default_icon_size(this.desktop_helper.panel_size);
 
-		Idle.add(() => {
-			this.buttons.foreach((id, button) => {
-				button.queue_resize();
-			});
-			return false;
+		this.buttons.foreach((id, button) => {
+			button.queue_resize();
 		});
 	}
 


### PR DESCRIPTION
## Description

This pull request moves icon scaling within the icon tasklist from the applet itself to each of the buttons, and provides a smooth scaling gradient for those icons between different panel sizes. Icon updates are now done on button size allocation, and only if the new allocation differs from the old allocation.

### Old Behavior

Icons would resize in predetermined steps, such as 24px to 48px to 96px.

https://user-images.githubusercontent.com/12981608/157320723-7db1d048-106b-457c-b035-1e92e4bf5fae.mp4

### New Behavior

Icons sourced by gicons are now scaled to a target size that approximates 2/3 of the size of the panel itself, up to an icon size of 54px, where it shifts to the panel size minus 18. This allows for icons to scale to much smaller and much larger sizes, while retaining desirable icon sizes for dock setups, and while maintaining the same icon size for the default panel size of 36px.

https://user-images.githubusercontent.com/12981608/157320237-3efd6160-654d-4bee-901b-5b33371443ea.mp4

**This video is representative of the scaling method, and NOT representative of the target icon sizes produced by the mentioned formulas.**

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
