### PR TITLE
Fix inconsistency when opening Raven

### DIFF
--- a/src/raven/main_view.vala
+++ b/src/raven/main_view.vala
@@ -77,6 +77,10 @@ namespace Budgie {
 			mpris = new MprisWidget();
 			box.pack_start(mpris, false, false, 0);
 
+			// Make sure everything is shown. Not having this can cause
+			// silent failures when switching stack pages or opening Raven.
+			scroll.show_all();
+
 			main_stack.notify["visible-child-name"].connect(on_name_change);
 			set_clean();
 			set_sound_widget_events();


### PR DESCRIPTION
## Description
Per the answer [here](https://stackoverflow.com/questions/22178524/gtk-named-stack-childs), if a stack child is not visible, asking the stack to set the visible child will silently fail, apparently even if the child being shown *is* visible.

The NotificationView widget already calls `show_all()` in its constructor, so the call only had to be added to the applet window. This fixes the case where clicking the notification bell fails to open the correct page, and possibly also fixes where clicking the Raven trigger for the first time sometimes fails to open Raven (it is technically open, but the elements aren't visible).

Thanks to @fossfreedom for finding that link!

Fixes #31

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
