### PR TITLE
New menu icon

### DIFF
--- a/data/icons/README
+++ b/data/icons/README
@@ -1,3 +1,6 @@
+The budgie-menu-symbolic.svg file was created by Campbell Jones and is
+licensed under the CC0 1.0 license.
+
 The notification-alert-symbolic.svg file is a modification of an
 icon found on 1001freedownloads, under the CC0 1.0 license
 

--- a/data/icons/actions/budgie-menu-symbolic.svg
+++ b/data/icons/actions/budgie-menu-symbolic.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="32" height="32" version="1.1" viewBox="0 0 8.5 8.5" xmlns="http://www.w3.org/2000/svg">
+ <g fill="#eee">
+  <rect x="1.6" y="1.6" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="3.7" y="1.6" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="5.8" y="1.6" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="1.6" y="3.7" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="3.7" y="3.7" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="5.8" y="3.7" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="1.6" y="5.8" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="3.7" y="5.8" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="5.8" y="5.8" width="1.1" height="1.1" rx=".16" ry=".16"/>
+ </g>
+</svg>

--- a/data/meson.build
+++ b/data/meson.build
@@ -11,6 +11,7 @@ version_file = configure_file(
 )
 
 actions_icons = [
+    join_paths('.', 'icons', 'actions', 'budgie-menu-symbolic.svg'),
     join_paths('.', 'icons', 'actions', 'notification-alert-symbolic.svg'),
     join_paths('.', 'icons', 'actions', 'notification-disabled-symbolic.svg'),
     join_paths('.', 'icons', 'actions', 'pane-hide-symbolic.svg'),

--- a/src/applets/budgie-menu/BudgieMenu.vala
+++ b/src/applets/budgie-menu/BudgieMenu.vala
@@ -21,6 +21,9 @@ public class BudgieMenuSettings : Gtk.Grid {
 	private Gtk.Switch? switch_menu_label;
 
 	[GtkChild]
+	private Gtk.Switch? switch_use_custom_icon;
+
+	[GtkChild]
 	private Gtk.Switch? switch_menu_compact;
 
 	[GtkChild]
@@ -43,6 +46,7 @@ public class BudgieMenuSettings : Gtk.Grid {
 	public BudgieMenuSettings(Settings? settings) {
 		this.settings = settings;
 		settings.bind("enable-menu-label", switch_menu_label, "active", SettingsBindFlags.DEFAULT);
+		settings.bind("use-custom-menu-icon", switch_use_custom_icon, "active", SettingsBindFlags.DEFAULT);
 		settings.bind("menu-compact", switch_menu_compact, "active", SettingsBindFlags.DEFAULT);
 		settings.bind("menu-headers", switch_menu_headers, "active", SettingsBindFlags.DEFAULT);
 		settings.bind("menu-categories-hover", switch_menu_categories_hover, "active", SettingsBindFlags.DEFAULT);
@@ -139,6 +143,7 @@ public class BudgieMenuApplet : Budgie.Applet {
 		layout.valign = Gtk.Align.CENTER;
 		valign = Gtk.Align.FILL;
 		halign = Gtk.Align.FILL;
+		on_settings_changed("use-custom-menu-icon");
 		on_settings_changed("enable-menu-label");
 		on_settings_changed("menu-icon");
 		on_settings_changed("menu-label");
@@ -182,15 +187,22 @@ public class BudgieMenuApplet : Budgie.Applet {
 		bool should_show = true;
 
 		switch (key) {
+			case "use-custom-menu-icon":
 			case "menu-icon":
-				string? icon = settings.get_string(key);
+				string? icon;
+				if (settings.get_boolean("use-custom-menu-icon")) {
+					icon = settings.get_string("menu-icon");
+				} else {
+					icon = "budgie-menu-symbolic";
+				}
+
 				if ("/" in icon) {
 					try {
 						Gdk.Pixbuf pixbuf = new Gdk.Pixbuf.from_file(icon);
 						img.set_from_pixbuf(pixbuf.scale_simple(this.pixel_size, this.pixel_size, Gdk.InterpType.BILINEAR));
 					} catch (Error e) {
 						warning("Failed to update Budgie Menu applet icon: %s", e.message);
-						img.set_from_icon_name("view-grid-symbolic", Gtk.IconSize.INVALID); // Revert to view-grid-symbolic
+						img.set_from_icon_name("start-here-symbolic", Gtk.IconSize.INVALID); // Revert to start-here-symbolic
 					}
 				} else if (icon == "") {
 					should_show = false;

--- a/src/applets/budgie-menu/com.solus-project.budgie-menu.gschema.xml
+++ b/src/applets/budgie-menu/com.solus-project.budgie-menu.gschema.xml
@@ -14,6 +14,12 @@
       <description>The menu label to display on the menu button</description>
     </key>
 
+    <key type="b" name="use-custom-menu-icon">
+      <default>false</default>
+      <summary>Use custom menu icon</summary>
+      <description>Use a custom menu icon on the menu button</description>
+    </key>
+
     <key type="s" name="menu-icon">
       <default>'start-here-symbolic'</default>
       <summary>Menu button icon</summary>

--- a/src/applets/budgie-menu/settings.ui
+++ b/src/applets/budgie-menu/settings.ui
@@ -47,7 +47,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">3</property>
+        <property name="top_attach">4</property>
       </packing>
     </child>
     <child>
@@ -59,7 +59,7 @@
       </object>
       <packing>
         <property name="left_attach">1</property>
-        <property name="top_attach">3</property>
+        <property name="top_attach">4</property>
       </packing>
     </child>
     <child>
@@ -71,7 +71,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">4</property>
+        <property name="top_attach">5</property>
       </packing>
     </child>
     <child>
@@ -83,7 +83,7 @@
       </object>
       <packing>
         <property name="left_attach">1</property>
-        <property name="top_attach">4</property>
+        <property name="top_attach">5</property>
       </packing>
     </child>
     <child>
@@ -120,7 +120,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">5</property>
+        <property name="top_attach">6</property>
       </packing>
     </child>
     <child>
@@ -132,7 +132,32 @@
       </object>
       <packing>
         <property name="left_attach">1</property>
-        <property name="top_attach">5</property>
+        <property name="top_attach">6</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label7">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="hexpand">True</property>
+        <property name="label" translatable="yes">Use Custom Menu Icon</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="switch_use_custom_icon">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">end</property>
+        <property name="hexpand">True</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">2</property>
       </packing>
     </child>
     <child>
@@ -145,7 +170,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">2</property>
+        <property name="top_attach">3</property>
       </packing>
     </child>
     <child>
@@ -184,7 +209,7 @@
       </object>
       <packing>
         <property name="left_attach">1</property>
-        <property name="top_attach">2</property>
+        <property name="top_attach">3</property>
       </packing>
     </child>
   </template>


### PR DESCRIPTION
## Description
This pull request adds a new symbolic menu icon made from scratch. This new icon is used by default in all new and existing installations after updating, unless the user enables the new "Use Custom Menu Icon" option in the Budgie Menu applet settings. If this option is *enabled,* the old default of `start-here-symbolic` is selected instead, which restores the old behavior.

The new icon was fully made from scratch using Inkscape. I've elected to license it under CC0 v1.0, and have mentioned this in the icons folder's README.

**New Icon**
![image](https://user-images.githubusercontent.com/12981608/158456108-8a112c5a-7002-4ef2-aa8c-9279ca6ade16.png)

**Papirus**
![image](https://user-images.githubusercontent.com/12981608/158456238-ef377b5c-3f88-4d46-b3c4-79f39446039e.png)

**Paper**
![image](https://user-images.githubusercontent.com/12981608/158456316-17b10105-b4a4-443c-807e-af4d53609c20.png)

**hicolor**
![image](https://user-images.githubusercontent.com/12981608/158456493-7f334fd9-4a60-4e4a-924d-6b67ee0353a2.png)


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
