### PR TITLE
Improve racyness when a notification is closed and another one shown in quick succession

### DIFF
--- a/src/daemon/notifications/dbus.vala
+++ b/src/daemon/notifications/dbus.vala
@@ -291,8 +291,7 @@
 			Gdk.Rectangle rect = mon.get_geometry();
 
 			/* Set the x, y position of the notification */
-			int x;
-			int y;
+			int x = 0, y = 0;
 			calculate_position(popup, rect, out x, out y);
 			popup.move(x, y);
 		}
@@ -304,27 +303,29 @@
 		private void calculate_position(Popup window, Gdk.Rectangle rect, out int x, out int y) {
 			var pos = (NotificationPosition) this.panel_settings.get_enum("notification-position");
 			var latest = this.popups.get(this.latest_popup_id);
+			bool latest_exists = false;
+			int existing_height = 0, existing_x = 0, existing_y = 0;
+
+			if (latest != null && !latest.destroying) {
+				latest_exists = true;
+				existing_height = latest.get_child().get_allocated_height();
+				latest.get_position(out existing_x, out existing_y);
+			}
 
 			switch (pos) {
 				case NotificationPosition.TOP_LEFT:
-					if (latest != null) { // If a notification is already being displayed
-						int nx;
-						int ny;
-						latest.get_position(out nx, out ny);
-						x = nx;
-						y = ny + latest.get_child().get_allocated_height() + BUFFER_ZONE;
+					if (latest_exists) { // If a notification is already being displayed
+						x = existing_x;
+						y = existing_y + existing_height + BUFFER_ZONE;
 					} else { // This is the first nofication on the screen
 						x = rect.x + BUFFER_ZONE;
 						y = rect.y + INITIAL_BUFFER_ZONE;
 					}
 					break;
 				case NotificationPosition.BOTTOM_LEFT:
-					if (latest != null) { // If a notification is already being displayed
-						int nx;
-						int ny;
-						latest.get_position(out nx, out ny);
-						x = nx;
-						y = ny - latest.get_child().get_allocated_height() - BUFFER_ZONE;
+					if (latest_exists) { // If a notification is already being displayed
+						x = existing_x;
+						y = existing_y - existing_height - BUFFER_ZONE;
 					} else { // This is the first nofication on the screen
 						x = rect.x + BUFFER_ZONE;
 
@@ -334,12 +335,9 @@
 					}
 					break;
 				case NotificationPosition.BOTTOM_RIGHT:
-					if (latest != null) { // If a notification is already being displayed
-						int nx;
-						int ny;
-						latest.get_position(out nx, out ny);
-						x = nx;
-						y = ny - latest.get_child().get_allocated_height() - BUFFER_ZONE;
+					if (latest_exists) { // If a notification is already being displayed
+						x = existing_x;
+						y = existing_y - existing_height - BUFFER_ZONE;
 					} else { // This is the first nofication on the screen
 						x = (rect.x + rect.width) - NOTIFICATION_WIDTH;
 						x -= BUFFER_ZONE; // Don't touch edge of the screen
@@ -351,12 +349,9 @@
 					break;
 				case NotificationPosition.TOP_RIGHT: // Top right should also be the default case
 				default:
-					if (latest != null) { // If a notification is already being displayed
-						int nx;
-						int ny;
-						latest.get_position(out nx, out ny);
-						x = nx;
-						y = ny + latest.get_child().get_allocated_height() + BUFFER_ZONE;
+					if (latest_exists) { // If a notification is already being displayed
+						x = existing_x;
+						y = existing_y + existing_height + BUFFER_ZONE;
 					} else { // This is the first nofication on the screen
 						x = (rect.x + rect.width) - NOTIFICATION_WIDTH;
 						x -= BUFFER_ZONE; // Don't touch edge of the screen

--- a/src/daemon/notifications/dbus.vala
+++ b/src/daemon/notifications/dbus.vala
@@ -303,11 +303,10 @@
 		private void calculate_position(Popup window, Gdk.Rectangle rect, out int x, out int y) {
 			var pos = (NotificationPosition) this.panel_settings.get_enum("notification-position");
 			var latest = this.popups.get(this.latest_popup_id);
-			bool latest_exists = false;
+			bool latest_exists = latest != null && !latest.destroying;
 			int existing_height = 0, existing_x = 0, existing_y = 0;
 
-			if (latest != null && !latest.destroying) {
-				latest_exists = true;
+			if (latest_exists) {
 				existing_height = latest.get_child().get_allocated_height();
 				latest.get_position(out existing_x, out existing_y);
 			}

--- a/src/daemon/notifications/popup.vala
+++ b/src/daemon/notifications/popup.vala
@@ -22,6 +22,8 @@ namespace Budgie.Notifications {
 
 		private uint expire_id { get; private set; }
 
+		public bool destroying { get; private set; default = false; }
+
 		public signal void Closed(NotificationCloseReason reason);
 
 		construct {
@@ -57,6 +59,7 @@ namespace Budgie.Notifications {
 		 * Destroy this notification popup.
 		 */
 		public void dismiss() {
+			this.destroying = true;
 			destroy();
 		}
 


### PR DESCRIPTION
## Description
There is a race condition where a notification may be closed and in the process of destruction, and a new notification is requested to be shown right after. This causes the position calculation to fail because the existing popup is no longer a Widget, but it's also not `null`.

This problem is addressed here by adding a boolean property to the popup widget that is set to `true` when `dismiss()` is called on it, and checking that property when we want to position a new notification. Additionally, move the latest notification check out of the `switch` branches, and getting our needed values as soon as possible.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
