### PR TITLE
Don't modify notification group HashTables while iterating over them

### DIFF
--- a/src/raven/notifications_group.vala
+++ b/src/raven/notifications_group.vala
@@ -109,11 +109,13 @@ namespace Budgie {
 		 * dismiss_all is responsible for dismissing all notifications
 		 */
 		public void dismiss_all() {
-			notifications.foreach((id, notification) => { // For reach notification
-				remove_notification(id); // Remove this notification
+			notifications.foreach_steal((id, notification) => {
+				list.remove(notification.get_parent());
+				notification.destroy();
+				dismissed_notification(id);
+				return true;
 			});
 
-			notifications.steal_all();
 			update_count();
 			dismissed_group(app_name);
 		}


### PR DESCRIPTION
## Description
This prevents a critical message when dismissing notification groups. When iterating over a HashTable using the `foreach` method, the table should not be modified. Instead, use `foreach_steal` to iterate and remove from the notifications table.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
