### PR TITLE
Remove delay in Abomination when opening apps

### DIFF
--- a/src/abomination/abomination.vala
+++ b/src/abomination/abomination.vala
@@ -72,16 +72,7 @@ namespace Budgie.Abomination {
 			}
 
 			this.screen.window_closed.connect(this.remove_app);
-			this.screen.window_opened.connect((window) => {
-				// just make sure that "closed" is always sent before "opened" signal.
-				// Otherwise some apps (e.g. Google Chrome with profile manager)
-				// might not properly reuse the pinned icon when grouping is disabled
-				// (second window open before first is closed)
-				Timeout.add(100, () => {
-					this.add_app(window);
-					return false;
-				});
-			});
+			this.screen.window_opened.connect(this.add_app);
 
 			this.screen.get_windows().foreach((window) => { // Init all our current running windows
 				this.add_app(window);
@@ -222,6 +213,8 @@ namespace Budgie.Abomination {
 			this.track_window_fullscreen_state(window, null); // Remove from fullscreen_windows and toggle state if necessary
 			if (app != null) { // App is defined
 				this.removed_app(app.get_group_name(), app); // Notify that we called remove
+			} else {
+				debug("Cannot remove %s", window.get_name());
 			}
 		}
 

--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -418,6 +418,18 @@ public class IconTasklistApplet : Budgie.Applet {
 		button.update();
 
 		this.remove_button(app.id.to_string());
+
+		// Google Chrome with profile manager will not properly reuse the
+		// pinned icon when grouping is disabled (second window open before first is closed)
+		if (button.pinned && !this.grouping) { // try re-parenting app
+			Budgie.Abomination.RunningApp first_app = this.abomination.get_first_app_of_group(app.get_group_name());
+			if (first_app == null) {
+				return;
+			}
+
+			this.on_app_closed(first_app);
+			this.on_app_opened(first_app);
+		}
 	}
 
 	private void on_active_window_changed() {


### PR DESCRIPTION
## Description

This was introduced in Abomination in an attempt to fix Chrome profile manager closing sequence but ended up breaking some other apps (such as Steam) closing sequence.

Instead, try to re-parent first app of group when an app associated with a pinned icon is closed so that the pinned button is reused.

Fixes #85

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
