### PR TITLE
Add more panel config options to panel.ini

### DIFF
--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -193,6 +193,12 @@ namespace Budgie {
 			this.update_dock_behavior();
 		}
 
+		public void update_shadow(bool visible) {
+			this.shadow_visible = visible;
+
+			this.settings.set_boolean(Budgie.PANEL_KEY_SHADOW, visible);
+		}
+
 		/**
 		* Specific for docks, regardless of transparency, and determines
 		* how our "screen blocked by thingy" policy works.


### PR DESCRIPTION
Includes autohide policy (Autohide: enum), transparency (Transparency: enum), dock mode (Dock: boolean), and shadow visibility (Shadow: boolean).

Additionally, this PR removes the ability to set panel transparency via a gsettings override. Downstreams that use this method to change default panel transparency will need to ship a modified panel.ini instead.  

Resolves #88.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
