### PR TITLE
Fix regression where non pinned icons were not reorderable in icon tasklist

### DIFF
--- a/src/abomination/RunningApp.vala
+++ b/src/abomination/RunningApp.vala
@@ -48,23 +48,6 @@ namespace Budgie.Abomination {
 			return this.group_object.get_name();
 		}
 
-		public string get_real_id(bool include_xid) {
-			string usable_app_id = this.id.to_string(); // Default to the xid of the app
-
-			if (this.app_info != null) { // If the app has DesktopAppInfo
-				string[] parts = this.app_info.get_filename().split("/"); // Taken from DesktopHelpers
-				string app_name = parts[parts.length - 1];
-
-				if (include_xid) { // Only include xid when we have app info since we default to the xid from the start
-					usable_app_id = "%s|%lu".printf(app_name, this.id);
-				} else { // No xid, use app_name
-					usable_app_id = app_name;
-				}
-			}
-
-			return usable_app_id;
-		}
-
 		public Wnck.Window get_window() {
 			return this.window;
 		}

--- a/src/applets/icon-tasklist/DesktopHelper.vala
+++ b/src/applets/icon-tasklist/DesktopHelper.vala
@@ -75,17 +75,17 @@ public class DesktopHelper : GLib.Object {
 	}
 
 	/**
-	* get_app_launcher will return the last past of an app_id string. Useful when handling the full path to a DesktopAppInfo
-	*/
-	public string get_app_launcher(string app_id) {
-		string[] parts = app_id.split("/");
-		return parts[parts.length - 1];
-	}
-
-	/**
 	 * Return the currently active workspace
 	 */
 	public Wnck.Workspace get_active_workspace() {
 		return screen.get_active_workspace();
+	}
+
+	/**
+	 * get_app_launcher will return the last past of an app_id string. Useful when handling the full path to a DesktopAppInfo
+	 */
+	public string get_app_launcher(string app_id) {
+		string[] parts = app_id.split("/");
+		return parts[parts.length - 1];
 	}
 }


### PR DESCRIPTION
## Description

This was due to the incorrect app ID being passed to the signal handler.
Instead we can pass the correct ID that we determine in IconTasklistApplet when instanciating the button.

This revert last attempt to fix the issue as it was causing other issues with Budgie settings and LibreOffice (and quite possibly the issue reported by @serebit in #93)

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
