### PR TITLE
Per-panel setting for applet spacing

### DIFF
--- a/src/lib/manager.vala
+++ b/src/lib/manager.vala
@@ -26,6 +26,7 @@ namespace Budgie {
 		public abstract void set_autohide(string uuid, Budgie.AutohidePolicy policy);
 		public abstract void set_dock_mode(string uuid, bool dock_mode);
 		public abstract void set_size(string uuid, int size);
+		public abstract void set_spacing(string uuid, int spacing);
 
 		public abstract void create_new_panel();
 		public abstract void delete_panel(string uuid);

--- a/src/lib/toplevel.vala
+++ b/src/lib/toplevel.vala
@@ -36,6 +36,11 @@ namespace Budgie {
 		*/
 		public int intended_size { public set ; public get; }
 
+		/**
+		* Our configured applet spacing
+		*/
+		public int intended_spacing { public set; public get; }
+
 		public bool shadow_visible { public set ; public get; }
 		public bool theme_regions { public set; public get; }
 		public bool dock_mode { public set; public get; default = false; }

--- a/src/panel/com.solus-project.budgie-panel.gschema.xml
+++ b/src/panel/com.solus-project.budgie-panel.gschema.xml
@@ -46,6 +46,12 @@
       <description>Height of panel if horizontal, or the width if it is vertical</description>
     </key>
 
+    <key type="i" name="spacing">
+      <default>2</default>
+      <summary>Applet spacing</summary>
+      <description>Space between each applet</description>
+    </key>
+
     <key enum="com.solus-project.budgie-panel.Transparency" name="transparency">
       <default>'none'</default>
       <summary>Panel transparency</summary>

--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -85,6 +85,9 @@ namespace Budgie {
 	/** Panel size */
 	public const string PANEL_KEY_SIZE = "size";
 
+	/** Panel spacing */
+	public const string PANEL_KEY_SPACING = "spacing";
+
 	/** Autohide policy */
 	public const string PANEL_KEY_AUTOHIDE = "autohide";
 
@@ -888,7 +891,7 @@ namespace Budgie {
 			AutohidePolicy policy;
 			bool dock_mode;
 			bool shadow_visible;
-			int size;
+			int size, spacing;
 
 			var settings = new Settings.with_path(Budgie.TOPLEVEL_SCHEMA, path);
 			Budgie.Panel? panel = new Budgie.Panel(this, uuid, settings);
@@ -906,11 +909,12 @@ namespace Budgie {
 
 			size = settings.get_int(Budgie.PANEL_KEY_SIZE);
 			panel.intended_size = (int)size;
-			this.show_panel(uuid, position, transparency, policy, dock_mode, shadow_visible);
+			spacing = (int) settings.get_int(Budgie.PANEL_KEY_SPACING);
+			this.show_panel(uuid, position, transparency, policy, dock_mode, shadow_visible, spacing);
 		}
 
 		void show_panel(string uuid, PanelPosition position, PanelTransparency transparency, AutohidePolicy policy,
-						bool dock_mode, bool shadow_visible) {
+						bool dock_mode, bool shadow_visible, int spacing) {
 
 			Budgie.Panel? panel = panels.lookup(uuid);
 			unowned Screen? scr;
@@ -927,6 +931,7 @@ namespace Budgie {
 			this.set_autohide(uuid, policy);
 			this.set_dock_mode(uuid, dock_mode);
 			this.set_shadow(uuid, shadow_visible);
+			this.set_spacing(uuid, spacing);
 		}
 
 		/**
@@ -942,6 +947,21 @@ namespace Budgie {
 
 			panel.intended_size = size;
 			this.update_screen();
+		}
+
+		/**
+		* Set spacing of the given panel
+		*/
+		public override void set_spacing(string uuid, int spacing) {
+			Budgie.Panel? panel = panels.lookup(uuid);
+
+			if (panel == null) {
+				warning("Asked to resize non-existent panel: %s", uuid);
+				return;
+			}
+
+			panel.intended_spacing = spacing;
+			panel.update_spacing();
 		}
 
 		/**
@@ -1264,6 +1284,7 @@ namespace Budgie {
 			bool dock_mode = false;
 			bool shadow_visible = true;
 			int size = -1;
+			int spacing = 2;
 
 			if (this.slots_available() < 1) {
 				warning("Asked to create panel with no slots available");
@@ -1291,6 +1312,9 @@ namespace Budgie {
 					}
 					if (new_defaults.has_key(name, "Size")) {
 						size = new_defaults.get_integer(name, "Size");
+					}
+					if (new_defaults.has_key(name, "Spacing")) {
+						spacing = new_defaults.get_integer(name, "Spacing");
 					}
 					if (new_defaults.has_key(name, "Dock")) {
 						dock_mode = new_defaults.get_boolean(name, "Dock");
@@ -1339,7 +1363,7 @@ namespace Budgie {
 			load_panel(uuid, false);
 
 			set_panels();
-			show_panel(uuid, position, transparency, policy, dock_mode, shadow_visible);
+			show_panel(uuid, position, transparency, policy, dock_mode, shadow_visible, spacing);
 
 			if (new_defaults == null || name == null) {
 				this.panel_added(uuid, panels.lookup(uuid));

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -278,6 +278,7 @@ namespace Budgie {
 			initial_config = new HashTable<string,Budgie.AppletInfo>(str_hash, str_equal);
 
 			intended_size = settings.get_int(Budgie.PANEL_KEY_SIZE);
+			intended_spacing = settings.get_int(Budgie.PANEL_KEY_SPACING);
 			this.manager = manager;
 
 			skip_taskbar_hint = true;
@@ -351,6 +352,7 @@ namespace Budgie {
 			end_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 2);
 			layout.pack_end(end_box, false, false, 0);
 			end_box.halign = Gtk.Align.END;
+			update_spacing();
 
 			this.theme_regions = this.settings.get_boolean(Budgie.PANEL_KEY_REGIONS);
 			this.notify["theme-regions"].connect(update_theme_regions);
@@ -424,6 +426,15 @@ namespace Budgie {
 			while (iter.next(out key, out info)) {
 				info.applet.panel_position_changed(this.position);
 			}
+		}
+
+		public void update_spacing() {
+			this.settings.set_int(Budgie.PANEL_KEY_SPACING, this.intended_spacing);
+
+			layout.set_spacing(this.intended_spacing);
+			start_box.set_spacing(this.intended_spacing);
+			center_box.set_spacing(this.intended_spacing);
+			end_box.set_spacing(this.intended_spacing);
 		}
 
 		public void destroy_children() {

--- a/src/panel/settings/settings_panel.vala
+++ b/src/panel/settings/settings_panel.vala
@@ -49,6 +49,9 @@ namespace Budgie {
 		private Gtk.SpinButton? spinbutton_size;
 		private ulong size_id;
 
+		private Gtk.SpinButton? spinbutton_spacing;
+		private ulong spacing_id;
+
 		Gtk.Button button_remove_panel;
 
 		unowned Budgie.DesktopManager? manager = null;
@@ -237,6 +240,14 @@ namespace Budgie {
 				_("Size"),
 				_("Set the size (width or height, depending on orientation) of this panel")));
 
+			spinbutton_spacing = new Gtk.SpinButton.with_range(0, 64, 1);
+			spinbutton_spacing.set_numeric(true);
+			spacing_id = spinbutton_spacing.value_changed.connect(this.set_spacing);
+			group.add_widget(spinbutton_spacing);
+			ret.add_row(new SettingsRow(spinbutton_spacing,
+				_("Spacing"),
+				_("Set the spacing between applets for this panel")));
+
 			/* Autohide */
 			combobox_autohide = new Gtk.ComboBox();
 			autohide_id = combobox_autohide.changed.connect(this.set_autohide);
@@ -333,6 +344,7 @@ namespace Budgie {
 			const string[] needed_props = {
 				"position",
 				"intended-size",
+				"spacing",
 				"transparency",
 				"autohide",
 				"shadow-visible",
@@ -374,6 +386,11 @@ namespace Budgie {
 					SignalHandler.block(this.spinbutton_size, this.size_id);
 					this.spinbutton_size.set_value(this.toplevel.intended_size);
 					SignalHandler.unblock(this.spinbutton_size, this.size_id);
+					break;
+				case "spacing":
+					SignalHandler.block(this.spinbutton_spacing, this.spacing_id);
+					this.spinbutton_spacing.set_value(this.toplevel.intended_spacing);
+					SignalHandler.unblock(this.spinbutton_spacing, this.spacing_id);
 					break;
 				case "transparency":
 					SignalHandler.block(this.combobox_transparency, this.transparency_id);
@@ -477,6 +494,13 @@ namespace Budgie {
 		*/
 		private void set_size() {
 			this.manager.set_size(this.toplevel.uuid, (int)this.spinbutton_size.get_value());
+		}
+
+		/**
+		* Update the panel spacing
+		*/
+		private void set_spacing() {
+			this.manager.set_spacing(this.toplevel.uuid, (int) this.spinbutton_spacing.get_value());
 		}
 
 		/**


### PR DESCRIPTION
## Description

This pull request adds a per-panel setting that defines the base spacing between applets, independent of CSS. This works via setting the spacing of each individual panel region, in addition to the spacing between the regions, so spacing between applets is consistent even at region boundaries. The default setting of 2 matches our current no-setting default, and the setting can be adjusted from a minimum value of 0 to a maximum value of 64.

The spacing is also adjustable in `panel.ini` via the `Spacing` key.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
