### PR TITLE
Use meson warning_level instead of global warning flags

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@ project(
     ],
     default_options: [
         'c_std=c11',
+        'warning_level=3'
     ],
 )
 
@@ -24,23 +25,6 @@ endif
 
 git = find_program('git', required: false)
 
-am_cflags = [
-    '-fstack-protector',
-    '-pedantic',
-    '-Wstrict-prototypes',
-    '-Wundef',
-    '-Werror-implicit-function-declaration',
-    '-Wformat',
-    '-Wformat-security',
-    '-Werror=format-security',
-    '-Wconversion',
-    '-Wunused-variable',
-    '-Wunreachable-code',
-    '-Wall',
-    '-W',
-]
-
-add_global_arguments(am_cflags, language: 'c')
 meson.add_install_script('scripts/mesonPostInstall.sh')
 
 # Budgie needs a minimum GNOME 40 stack with GTK 3.24+
@@ -149,6 +133,7 @@ gvc = subproject('gvc',
         'c_std=c89',
         'static=false',
         'pkglibdir=@0@'.format(rpath_libdir),
+        'warning_level=0',
     ],
 )
 

--- a/meson.build
+++ b/meson.build
@@ -133,6 +133,8 @@ gvc = subproject('gvc',
         'c_std=c89',
         'static=false',
         'pkglibdir=@0@'.format(rpath_libdir),
+        'package_name=' + meson.project_name(),
+        'package_version=' + meson.project_version(),
         'warning_level=0',
     ],
 )


### PR DESCRIPTION
## Description

This PR is a simple change that sets `warning_level` to 3 across the entire project, with an override for the gvc subproject to a `warning_level` of 0 (as we can't fix any of these warnings due to it being a subproject, there's no real point in printing them). Additionally, we now set the project_name and project_version args when compiling gvc.This results in a reduction in compile log lines from 879 to 546 on current master, and additionally, still prints every warning in the main Budgie codebase that was printed with the global cflags.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
