### PR TITLE
Fix various compile-time warnings in Vala code

### DIFF
--- a/src/applets/notifications/NotificationsApplet.vala
+++ b/src/applets/notifications/NotificationsApplet.vala
@@ -151,11 +151,13 @@ public class NotificationsApplet : Budgie.Applet {
 			return Gdk.EVENT_PROPAGATE;
 		}
 
-		try {
-			raven_proxy.ToggleNotificationsView.begin();
-		} catch (Error e) {
-			message("Failed to toggle Raven: %s", e.message);
-		}
+		raven_proxy.ToggleNotificationsView.begin((obj,res) => {
+			try {
+				raven_proxy.ToggleNotificationsView.end(res);
+			} catch (Error e) {
+				message("Failed to toggle Raven: %s", e.message);
+			}
+		});
 
 		return Gdk.EVENT_STOP;
 	}

--- a/src/applets/raven-trigger/RavenTriggerApplet.vala
+++ b/src/applets/raven-trigger/RavenTriggerApplet.vala
@@ -77,11 +77,15 @@ public class RavenTriggerApplet : Budgie.Applet {
 		if (raven_proxy == null) {
 			return false;
 		}
-		try {
-			raven_proxy.ToggleAppletView.begin();
-		} catch (Error e) {
-			message("Error in dbus: %s", e.message);
-		}
+
+		raven_proxy.ToggleAppletView.begin((obj,res) => {
+			try {
+				raven_proxy.ToggleAppletView.end(res);
+			} catch (Error e) {
+				message("Error in dbus: %s", e.message);
+			}
+		});
+
 		return false;
 	}
 

--- a/src/daemon/endsession.vala
+++ b/src/daemon/endsession.vala
@@ -35,9 +35,6 @@ namespace Budgie {
 		public signal void Opened();
 
 		[GtkChild]
-		private unowned Gtk.Button? button_cancel;
-
-		[GtkChild]
 		private unowned Gtk.Button? button_logout;
 
 		[GtkChild]

--- a/src/daemon/manager.vala
+++ b/src/daemon/manager.vala
@@ -48,9 +48,9 @@ namespace Budgie {
 		* Attempt registration with the Session Manager
 		*/
 		private async bool register_with_session() {
-			try {
-				sclient = yield LibSession.register_with_session("budgie-daemon");
-			} catch (Error e) {
+			sclient = yield LibSession.register_with_session("budgie-daemon");
+
+			if (sclient == null) {
 				return false;
 			}
 

--- a/src/daemon/menus.vala
+++ b/src/daemon/menus.vala
@@ -119,7 +119,7 @@ namespace Budgie {
 				if (desktop_menu.get_visible()) {
 					desktop_menu.hide();
 				} else {
-					desktop_menu.popup(null, null, null, button, timestamp == 0 ? Gdk.CURRENT_TIME : timestamp);
+					desktop_menu.popup_at_pointer(null);
 				}
 				return false;
 			});
@@ -134,7 +134,7 @@ namespace Budgie {
 				return;
 			}
 			action_menu = new Wnck.ActionMenu(active_window);
-			action_menu.popup(null, null, null, 3, Gdk.CURRENT_TIME);
+			action_menu.popup_at_pointer(null);
 			this.xid = xid;
 		}
 	}

--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -200,9 +200,9 @@ namespace Budgie {
 		}
 
 		private async bool register_with_session() {
-			try {
-				sclient = yield LibSession.register_with_session("budgie-panel");
-			} catch (Error e) {
+			sclient = yield LibSession.register_with_session("budgie-panel");
+
+			if (sclient == null) {
 				return false;
 			}
 
@@ -467,7 +467,7 @@ namespace Budgie {
 		*/
 		public void on_monitors_changed() {
 			var scr = Gdk.Screen.get_default();
-			var mon = scr.get_primary_monitor();
+			var dis = scr.get_display();
 			HashTableIter<string,Budgie.Panel?> iter;
 			unowned string uuid;
 			unowned Budgie.Panel panel;
@@ -480,16 +480,20 @@ namespace Budgie {
 			/* When we eventually get monitor-specific panels we'll find the ones that
 			* were left stray and find new homes, or temporarily disable
 			* them */
-			for (int i = 0; i < scr.get_n_monitors(); i++) {
-				Gdk.Rectangle usable_area;
-				scr.get_monitor_geometry(i, out usable_area);
+			for (int i = 0; i < dis.get_n_monitors(); i++) {
+				Gdk.Monitor mon = dis.get_monitor(i);
+				Gdk.Rectangle usable_area = mon.get_geometry();
 				Budgie.Screen? screen = new Budgie.Screen();
 				screen.area = usable_area;
 				screen.slots = PanelPosition.NONE;
 				screens.insert(i, screen);
+
+				if (mon.is_primary()) {
+					primary_monitor = i;
+				}
 			}
 
-			primary = screens.lookup(mon);
+			primary = screens.lookup(primary_monitor);
 
 			/* Fix all existing panels here */
 			Gdk.Rectangle raven_screen;
@@ -506,7 +510,6 @@ namespace Budgie {
 				/* Re-take the position */
 				primary.slots |= panel.position;
 			}
-			this.primary_monitor = mon;
 
 			raven_screen = primary.area;
 			if (top != null) {
@@ -581,7 +584,14 @@ namespace Budgie {
 				this.do_reset();
 			}
 			var scr = Gdk.Screen.get_default();
-			primary_monitor = scr.get_primary_monitor();
+			var dis = scr.get_display();
+
+			for (int i = 0; i < dis.get_n_monitors(); i++) {
+				if (dis.get_monitor(i).is_primary()) {
+					primary_monitor = i;
+				}
+			}
+
 			scr.monitors_changed.connect(this.on_monitors_changed);
 			scr.size_changed.connect(this.on_monitors_changed);
 

--- a/src/polkit/polkitdialog.vala
+++ b/src/polkit/polkitdialog.vala
@@ -305,9 +305,9 @@ namespace Budgie {
 		}
 
 		private async bool register_with_session() {
-			try {
-				sclient = yield LibSession.register_with_session("budgie-polkit");
-			} catch (Error e) {
+			sclient = yield LibSession.register_with_session("budgie-polkit");
+
+			if (sclient == null) {
 				return false;
 			}
 

--- a/src/raven/powerstrip.vala
+++ b/src/raven/powerstrip.vala
@@ -78,15 +78,17 @@ namespace Budgie {
 			btn = new Gtk.Button.from_icon_name("system-log-out-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 			power_btn = btn;
 			btn.clicked.connect(() => {
-				try {
-					raven.set_expanded(false);
-					if (session == null) {
-						return;
-					}
-					session.Logout.begin(0);
-				} catch (Error e) {
-					message("Error invoking end session dialog: %s", e.message);
+				raven.set_expanded(false);
+				if (session == null) {
+					return;
 				}
+				session.Logout.begin(0, (obj,res) => {
+					try {
+						session.Logout.end(res);
+					} catch (Error e) {
+						message("Error invoking end session dialog: %s", e.message);
+					}
+				});
 			});
 			btn.halign = Gtk.Align.START;
 			btn.get_style_context().add_class("flat");

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -306,11 +306,14 @@ namespace Budgie {
 				warning("Raven does not appear to be running!");
 				return;
 			}
-			try {
-				raven_proxy.ClearNotifications.begin();
-			} catch (Error e) {
-				warning("Unable to ClearNotifications() in Raven: %s", e.message);
-			}
+
+			raven_proxy.ClearNotifications.begin((obj,res) => {
+				try {
+					raven_proxy.ClearNotifications.end(res);
+				} catch (Error e) {
+					warning("Unable to ClearNotifications() in Raven: %s", e.message);
+				}
+			});
 		}
 
 		/* Binding for toggle-raven activated */
@@ -321,11 +324,14 @@ namespace Budgie {
 				warning("Raven does not appear to be running!");
 				return;
 			}
-			try {
-				raven_proxy.ToggleAppletView.begin();
-			} catch (Error e) {
-				warning("Unable to ToggleAppletView() in Raven: %s", e.message);
-			}
+
+			raven_proxy.ToggleAppletView.begin((obj,res) => {
+				try {
+					raven_proxy.ToggleAppletView.end(res);
+				} catch (Error e) {
+					warning("Unable to ToggleAppletView() in Raven: %s", e.message);
+				}
+			});
 		}
 
 		/* Binding for toggle-notifications activated */
@@ -336,11 +342,14 @@ namespace Budgie {
 				warning("Raven does not appear to be running!");
 				return;
 			}
-			try {
-				raven_proxy.ToggleNotificationsView.begin();
-			} catch (Error e) {
-				warning("Unable to ToggleNotificationsView() in Raven: %s", e.message);
-			}
+
+			raven_proxy.ToggleNotificationsView.begin((obj,res) => {
+				try {
+					raven_proxy.ToggleNotificationsView.end(res);
+				} catch (Error e) {
+					warning("Unable to ToggleNotificationsView() in Raven: %s", e.message);
+				}
+			});
 		}
 
 		/* Set up the proxy when raven appears */
@@ -370,11 +379,14 @@ namespace Budgie {
 				}
 			} else {
 				Idle.add(() => {
-					try {
-						panel_proxy.ActivateAction.begin((int) PanelAction.MENU);
-					} catch (Error e) {
-						message("Unable to ActivateAction for menu: %s", e.message);
-					}
+					panel_proxy.ActivateAction.begin((int) PanelAction.MENU, (obj,res) => {
+						try {
+							panel_proxy.ActivateAction.end(res);
+						} catch (Error e) {
+							message("Unable to ActivateAction for menu: %s", e.message);
+						}
+					});
+
 					return false;
 				});
 			}
@@ -525,11 +537,14 @@ namespace Budgie {
 				if (menu_proxy == null) {
 					return CLUTTER_EVENT_STOP;
 				}
-				try {
-					menu_proxy.ShowDesktopMenu.begin(3, 0);
-				} catch (Error e) {
-					message("Error invoking MenuManager: %s", e.message);
-				}
+
+				menu_proxy.ShowDesktopMenu.begin(3, 0, (obj,res) => {
+					try {
+						menu_proxy.ShowDesktopMenu.end(res);
+					} catch (Error e) {
+						message("Error invoking MenuManager: %s", e.message);
+					}
+				});
 			} else {
 				return CLUTTER_EVENT_PROPAGATE;
 			}
@@ -566,11 +581,14 @@ namespace Budgie {
 			}
 			Timeout.add(100, () => {
 				uint32 xid = (uint32)window.get_xwindow();
-				try {
-					menu_proxy.ShowWindowMenu.begin(xid, 3, 0);
-				} catch (Error e) {
-					message("Error invoking MenuManager: %s", e.message);
-				}
+				menu_proxy.ShowWindowMenu.begin(xid, 3, 0, (obj, res) => {
+					try {
+						menu_proxy.ShowWindowMenu.end(res);
+					} catch (Error e) {
+						message("Error invoking MenuManager: %s", e.message);
+					}
+				});
+
 				return false;
 			});
 		}
@@ -984,21 +1002,21 @@ namespace Budgie {
 			}
 		}
 
-		static int tab_sort(Meta.Window a, Meta.Window b) {
-			uint32 at;
-			uint32 bt;
+		//  static int tab_sort(Meta.Window a, Meta.Window b) {
+		//  	uint32 at;
+		//  	uint32 bt;
 
-			at = a.get_user_time();
-			bt = a.get_user_time();
+		//  	at = a.get_user_time();
+		//  	bt = a.get_user_time();
 
-			if (at < bt) {
-				return -1;
-			}
-			if (at > bt) {
-				return 1;
-			}
-			return 0;
-		}
+		//  	if (at < bt) {
+		//  		return -1;
+		//  	}
+		//  	if (at > bt) {
+		//  		return 1;
+		//  	}
+		//  	return 0;
+		//  }
 
 		static int tab_sort_reverse(Meta.Window a, Meta.Window b) {
 			uint32 at;
@@ -1196,12 +1214,15 @@ namespace Budgie {
 		public const int SWITCH_TIMEOUT = 250;
 		public override void switch_workspace(int from, int to, Meta.MotionDirection direction) {
 			if (raven_proxy != null) { // Raven proxy is defined
-				try {
-					raven_proxy.Dismiss.begin(); // Dismiss
-					Timeout.add(200, () => {return false;}); // Delay until animation is complete. Looks janky otherwise
-				} catch (Error e) {
-					warning("Failed to dismiss Raven: %s", e.message);
-				}
+				raven_proxy.Dismiss.begin((obj,res) => {
+					try {
+						raven_proxy.Dismiss.end(res);
+					} catch (Error e) {
+						warning("Failed to dismiss Raven: %s", e.message);
+					}
+				}); // Dismiss
+
+				Timeout.add(200, () => {return false;}); // Delay until animation is complete. Looks janky otherwise
 			}
 
 			bool use_animations = iface_settings.get_boolean("enable-animations");


### PR DESCRIPTION
## Description
This PR fixes various compile-time Vala warnings with rewritten code. The different types of fixes are listed below.

- Replacing try/catch surrounding a `begin` call with a try/catch *within* a `begin` call - this is the intended way to catch errors thrown by async functions
- Removing (button_cancel) or commenting out (tab_sort) unused variables and functions
- Replacing the deprecated `popup` call with `popup_at_pointer`
- Using a null check rather than a try/catch with session manager registration, as this function never throws an exception and merely returns null on failure
- Using the `Gdk.Monitor` API for storing monitors and their geometry, along with storing the primary monitor

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
