### PR TITLE
Fixes spec compliance for closing notifications

### DIFF
--- a/src/daemon/notifications/dbus.vala
+++ b/src/daemon/notifications/dbus.vala
@@ -150,7 +150,7 @@
 		/**
 		 * Signal emitted when a notification is closed.
 		 */
-		public signal void NotificationClosed(uint32 id, NotificationCloseReason reason);
+		public signal void NotificationClosed(uint32 id, uint32 reason);
 
 		/**
 		 * Returns the capabilities of this DBus Notification server.


### PR DESCRIPTION
## Description

Per the Freedesktop Notifications spec, the `NotificationClosed` method must be called with two `uint32` types. Vala enum values are of type `int32`, and this can break applications. Simply changing the method signature seems to do the trick.

Validated by:
1. `dbus-monitor interface=org.freedesktop.Notifications`
2. `notify-send foo`
3. Seeing:
```
signal time=1651504477.875076 sender=:1.41 -> destination=(null destination) serial=77 path=/org/freedesktop/Notifications; interface=org.freedesktop.Notifications; member=NotificationClosed
   uint32 2
   uint32 2
```

Fixes #118

### Changelog Text

Fix `NotificationClosed` DBus signature to match the spec

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
