### PR TITLE
Rewrite initial applet layout to prevent position desync

### DIFF
--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -518,7 +518,6 @@ namespace Budgie {
 				return (int) (a.position > b.position) - (int) (a.position < b.position);
 			};
 
-			/* Two loops so we can track when we've fully loaded the panel */
 			lock (expected_uuids) {
 				for (int i = 0; i < applets.length; i++) {
 					this.expected_uuids.append(applets[i]);
@@ -533,10 +532,8 @@ namespace Budgie {
 					Budgie.AppletInfo? info = this.manager.load_applet_instance(applets[i], out name);
 
 					if (info == null) {
-						/* Faiiiil */
 						if (name == null) {
 							unowned List<string?> g = expected_uuids.find_custom(applets[i], strcmp);
-							/* TODO: No longer expecting this guy to load */
 							if (g != null) {
 								expected_uuids.remove_link(g);
 							}
@@ -551,7 +548,6 @@ namespace Budgie {
 						}
 					}
 
-					/* um add this bro to the panel :o */
 					if (info.alignment == "start") {
 						start_applets.insert_sorted(info, infocmp);
 					} else if (info.alignment == "center") {

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -514,11 +514,19 @@ namespace Budgie {
 				return;
 			}
 
+			CompareFunc<Budgie.AppletInfo?> infocmp = (a, b) => {
+				return (int) (a.position > b.position) - (int) (a.position < b.position);
+			};
+
 			/* Two loops so we can track when we've fully loaded the panel */
 			lock (expected_uuids) {
 				for (int i = 0; i < applets.length; i++) {
 					this.expected_uuids.append(applets[i]);
 				}
+
+				var start_applets = new List<Budgie.AppletInfo?>();
+				var center_applets = new List<Budgie.AppletInfo?>();
+				var end_applets = new List<Budgie.AppletInfo?>();
 
 				for (int i = 0; i < applets.length; i++) {
 					string? name = null;
@@ -533,14 +541,37 @@ namespace Budgie {
 								expected_uuids.remove_link(g);
 							}
 							message("Unable to load invalid applet: %s", applets[i]);
+							applet_removed(applets[i]);
 							continue;
 						}
-						this.add_pending(applets[i], name);
-						manager.modprobe(name);
-					} else {
-						/* um add this bro to the panel :o */
-						this.add_applet(info);
+
+						info = this.add_pending(applets[i], name);
+						if (info == null) {
+							continue;
+						}
 					}
+
+					/* um add this bro to the panel :o */
+					if (info.alignment == "start") {
+						start_applets.insert_sorted(info, infocmp);
+					} else if (info.alignment == "center") {
+						center_applets.insert_sorted(info, infocmp);
+					} else {
+						end_applets.insert_sorted(info, infocmp);
+					}
+				}
+
+				for (int i = 0; i < start_applets.length(); i++) {
+					start_applets.nth_data(i).position = i;
+					add_applet(start_applets.nth_data(i));
+				}
+				for (int i = 0; i < center_applets.length(); i++) {
+					center_applets.nth_data(i).position = i;
+					add_applet(center_applets.nth_data(i));
+				}
+				for (int i = 0; i < end_applets.length(); i++) {
+					end_applets.nth_data(i).position = i;
+					add_applet(end_applets.nth_data(i));
 				}
 			}
 		}
@@ -899,13 +930,13 @@ namespace Budgie {
 			return;
 		}
 
-		void add_pending(string uuid, string plugin_name) {
+		Budgie.AppletInfo? add_pending(string uuid, string plugin_name) {
 			string? rname = null;
 			unowned HashTable<string,string>? table = null;
 
 			if (!this.manager.is_extension_valid(plugin_name)) {
 				warning("Not adding invalid plugin: %s %s", plugin_name, uuid);
-				return;
+				return null;
 			}
 
 			if (!this.manager.is_extension_loaded(plugin_name)) {
@@ -915,23 +946,23 @@ namespace Budgie {
 					if (!table.contains(uuid)) {
 						table.insert(uuid, uuid);
 					}
-					return;
+					return null;
 				}
 				/* Looks insane but avoids copies */
 				pending.insert(plugin_name, new HashTable<string,string>(str_hash, str_equal));
 				table = pending.lookup(plugin_name);
 				table.insert(uuid, uuid);
 				this.manager.modprobe(plugin_name);
-				return;
+				return null;
 			}
 
 			/* Already exists */
 			Budgie.AppletInfo? info = this.manager.load_applet_instance(uuid, out rname);
 			if (info == null) {
 				critical("Failed to load applet when we know it exists");
-				return;
+				return null;
 			}
-			this.add_applet(info);
+			return info;
 		}
 
 		public override void map() {


### PR DESCRIPTION
## Description

Rather than adding applets directly to the panel on initial panel load, the `load_applets` function instead uses intermediate region lists sorted by the info's desired position. Once all applet info have been added to the region lists, each applet's info is updated with its actual position within the list, and is then added to the panel. This prevents issues with applets being uninstalled before being removed from the panel, and thus should resolve #72, along with other applet ordering issues that could be the result of initial race conditions.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
