### PR TITLE
Set a mininum expiry timeout for notification popups

### DIFF
--- a/src/daemon/notifications/dbus.vala
+++ b/src/daemon/notifications/dbus.vala
@@ -196,7 +196,18 @@
 			int32 expire_timeout
 		) throws DBusError, IOError {
 			var id = (replaces_id != 0 ? replaces_id : ++notif_id);
-			var notification = new Notification(id, app_name, app_icon, summary, body, actions, hints, expire_timeout);
+			var expires = expire_timeout;
+
+			// The spec says that an expiry_timeout of 0 means that the
+			// notification should never expire. That doesn't really make
+			// sense for our implementation however, since this only handles
+			// popups. Notification "storage" is done seperately by Raven.
+			if (expires < 6000) {
+				// Let's have a 6 second minimum showing time
+				expires = 6000;
+			}
+
+			var notification = new Notification(id, app_name, app_icon, summary, body, actions, hints, expires);
 
 			string settings_app_name = app_name;
 			bool should_show = true; // Default to showing notification

--- a/src/daemon/notifications/dbus.vala
+++ b/src/daemon/notifications/dbus.vala
@@ -13,6 +13,9 @@
 	public const string NOTIFICATION_DBUS_NAME = "org.budgie_desktop.Notifications";
 	public const string NOTIFICATION_DBUS_OBJECT_PATH = "/org/budgie_desktop/Notifications";
 
+	const int32 MINIMUM_EXPIRY = 6000;
+	const int32 MAXIMUM_EXPIRY = 12000;
+
 	[DBus (name="org.buddiesofbudgie.budgie.Dispatcher")]
 	public class Dispatcher : Object {
 		/**
@@ -196,16 +199,14 @@
 			int32 expire_timeout
 		) throws DBusError, IOError {
 			var id = (replaces_id != 0 ? replaces_id : ++notif_id);
-			var expires = expire_timeout;
 
 			// The spec says that an expiry_timeout of 0 means that the
 			// notification should never expire. That doesn't really make
 			// sense for our implementation however, since this only handles
 			// popups. Notification "storage" is done seperately by Raven.
-			if (expires < 6000) {
-				// Let's have a 6 second minimum showing time
-				expires = 6000;
-			}
+			// All of that is to say: clamp the expiry
+			var expires = expire_timeout < MINIMUM_EXPIRY ? MINIMUM_EXPIRY : expire_timeout;
+			expires = expires > MAXIMUM_EXPIRY ? MAXIMUM_EXPIRY : expires;
 
 			var notification = new Notification(id, app_name, app_icon, summary, body, actions, hints, expires);
 

--- a/src/daemon/notifications/dbus.vala
+++ b/src/daemon/notifications/dbus.vala
@@ -205,8 +205,7 @@
 			// sense for our implementation however, since this only handles
 			// popups. Notification "storage" is done seperately by Raven.
 			// All of that is to say: clamp the expiry
-			var expires = expire_timeout < MINIMUM_EXPIRY ? MINIMUM_EXPIRY : expire_timeout;
-			expires = expires > MAXIMUM_EXPIRY ? MAXIMUM_EXPIRY : expires;
+			var expires = expire_timeout.clamp(MINIMUM_EXPIRY, MAXIMUM_EXPIRY);
 
 			var notification = new Notification(id, app_name, app_icon, summary, body, actions, hints, expires);
 

--- a/src/daemon/notifications/popup.vala
+++ b/src/daemon/notifications/popup.vala
@@ -11,8 +11,6 @@
 
 namespace Budgie.Notifications {
 	public const int NOTIFICATION_WIDTH = 400;
-	public const int MIN_TIMEOUT = 4000;
-	public const int MAX_TIMEOUT = 10000;
 
 	/**
 	 * This class is a notification popup with no content in it.
@@ -82,14 +80,7 @@ namespace Budgie.Notifications {
 				Source.remove(this.expire_id);
 			}
 
-			var t = timeout;
-			if (timeout < MIN_TIMEOUT && timeout != 0) {
-				t = MIN_TIMEOUT;
-			} else if (timeout > MAX_TIMEOUT) {
-				t = MAX_TIMEOUT;
-			}
-
-			this.expire_id = Timeout.add(t, do_expire, Priority.HIGH);
+			this.expire_id = Timeout.add(timeout, do_expire, Priority.HIGH);
 		}
 
 		/**


### PR DESCRIPTION
## Description
Some applications set a timeout of 0, which the spec says means that it should never expire. Our implementation doesn't really fit that, since persistence is done by Raven, not the notification server. So, we should have a minimum show time for the popups to ensure that one is actually shown when it should be.

Fixes #129

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
