### PR TITLE
Reset ITL buttons if group updated while pinned

### DIFF
--- a/src/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/applets/icon-tasklist/IconTasklistApplet.vala
@@ -171,7 +171,16 @@ public class IconTasklistApplet : Budgie.Applet {
 				return;
 			}
 
-			wrapper.gracefully_die();
+			if (!button.pinned) {
+				wrapper.gracefully_die();
+			} else {
+				// the button that we were going to replace is pinned, so instead of removing it from the view, 
+				// just remove its class group and first app, then update it visually. this prevents apps like
+				// the LibreOffice launcher from vanishing after a document is opened, despite being pinned 
+				button.set_class_group(null);
+				button.first_app = null;
+				button.update();
+			}
 
 			this.remove_button(window.get_xid().to_string());
 			this.on_app_opened(app);


### PR DESCRIPTION
## Description

Rather than always removing a button wrapper in ITL when its group is replaced, this patch adds a check for whether or not the button is pinned. If it is, the applet instead removes the button's class group and first_app, then updates it visually, essentially cutting it off from the group change. Then the function proceeds normally, which creates a new button with the new group. For example, if the LibreOffice launcher is pinned and a document is opened within it, the LibreOffice launcher button will cease to show as "running", and a new button will appear for the application associated with that document.

Fixes #107.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
