### PR TITLE
fix broken C std for gvc subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,7 +130,6 @@ with_polkit = get_option('with-polkit')
 # Get gvc built before we do anything
 gvc = subproject('gvc',
     default_options: [
-        'c_std=c89',
         'static=false',
         'pkglibdir=@0@'.format(rpath_libdir),
         'package_name=' + meson.project_name(),


### PR DESCRIPTION
Historically, Meson didn't know how to set c_std for a subproject at all. Meson 0.63.0 adds support for this, so the default_options kwarg to subproject now begins to respect this.

budgie-desktop uses c11, but artificially sets c89 for the gvc submodule. However, this does not actually work... the build then errors out when trying to build `subprojects/gvc/test-audio-device-selection.p/test-audio-device-selection.c.o`

Remove the faulty argument.

Fixes regression in commit 3d6d71c167dd9742cd072e7e6a3453c23ebb2658.