### PR TITLE
Rename the appindexer library to have a consistent budgie naming convention

### DIFF
--- a/src/appindexer/meson.build
+++ b/src/appindexer/meson.build
@@ -7,7 +7,7 @@ appindexer_sources = [
 ]
 
 libappindexer = shared_library(
-    'appindexer',
+    'budgie-appindexer',
     appindexer_sources,
     dependencies: [
         dep_gee,


### PR DESCRIPTION
## Description
Current built libraries have a budgie naming convention - either libbudgie* or libraven*.

This PR ensures the new appindexer library name is similarly names i.e. now libbudgie-appindexer

Tested by removing /usr/lib/libappindexer* and building the project from this branch.

Logging out and logging in produces no errors and the menu responds as expected to new/removed apps

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
