### PR TITLE
Fix Budgie Menu view not resetting on open

### DIFF
--- a/src/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/src/applets/budgie-menu/BudgieMenuWindow.vala
@@ -186,12 +186,10 @@ public class BudgieMenuWindow : Budgie.Popover {
 		if (clear_search) {
 			this.search_entry.text = "";
 		}
+
+		this.view.on_show();
 	}
 
-	/**
-	 * We need to make some changes to our display before we go showing ourselves
-	 * again! :)
-	 */
 	public override void show() {
 		this.reset(true);
 		base.show();

--- a/src/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/src/applets/budgie-menu/BudgieMenuWindow.vala
@@ -178,6 +178,7 @@ public class BudgieMenuWindow : Budgie.Popover {
 	 * If `clear_search` is set to true, the search entry text will be cleared.
 	 */
 	public void reset(bool clear_search) {
+		this.view.on_show();
 		this.overlay_menu.set_reveal_child(false);
 		this.search_entry.sensitive = true;
 		this.search_entry.grab_focus();
@@ -186,8 +187,6 @@ public class BudgieMenuWindow : Budgie.Popover {
 		if (clear_search) {
 			this.search_entry.text = "";
 		}
-
-		this.view.on_show();
 	}
 
 	public override void show() {

--- a/src/applets/budgie-menu/views/ListView.vala
+++ b/src/applets/budgie-menu/views/ListView.vala
@@ -465,15 +465,15 @@ public class ApplicationListView : ApplicationView {
 	 * We need to make some changes to our display before we go showing ourselves
 	 * again! :)
 	 */
-	public override void show() {
-		this.current_category = null;
+	public override void on_show() {
 		this.all_categories.set_active(true);
+		this.update_category(all_categories);
+
 		this.applications.select_row(null);
 		this.content_scroll.get_vadjustment().set_value(0);
 		this.categories_scroll.get_vadjustment().set_value(0);
 		this.categories.sensitive = true;
 
-		base.show();
 		if (!this.compact_mode) {
 			this.categories_scroll.show_all();
 		} else {

--- a/src/applets/budgie-menu/views/View.vala
+++ b/src/applets/budgie-menu/views/View.vala
@@ -40,6 +40,12 @@ public abstract class ApplicationView : Gtk.Box {
 	public abstract void on_search_entry_activated();
 
 	/**
+	 * Performs any work that should be done to the view when the menu
+	 * is opened, e.g. resetting the current category or invalidating filters.
+	 */
+	public abstract void on_show();
+
+	/**
 	 * Refreshes the entire application view.
 	 */
 	public abstract void refresh(Budgie.AppIndex app_tracker);


### PR DESCRIPTION
## Description

The previous `show()` function was only ever actually called when the widget is first shown. This adds a new abstract function for views to implement that gets called whenever the menu is opened, so any cleanup actions can be reliably performed.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
