### PR TITLE
Obtain custom timezone using the schema key name (resolves #164)

### DIFF
--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -211,7 +211,7 @@ public class ClockApplet : Budgie.Applet {
 				case "use-custom-timezone":
 				case "custom-timezone":
 					if (settings.get_boolean("use-custom-timezone")) {
-						string custom_tz = settings.get_string("custom_timezone");
+						string custom_tz = settings.get_string("custom-timezone");
 						try {
 							this.clock_timezone = new TimeZone.identifier(custom_tz);
 						} catch (Error e) {


### PR DESCRIPTION
## Description
For #164 
the schema key name and the name used when obtaining it from the code is mismatched.

This PR changes the code to use the schema key name "custom-timezone"


### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
