### PR TITLE
Revert the xsession rename - closes #173

### DIFF
--- a/src/session/meson.build
+++ b/src/session/meson.build
@@ -105,7 +105,7 @@ xsession_conf = configure_file(
 # Now merge the translations of the .desktop.in to a .desktop
 custom_target('desktop-file-xsession',
     input : xsession_conf,
-    output : 'org.buddiesofbudgie.BudgieDesktop.desktop',
+    output : 'budgie-desktop.desktop',
     command : [intltool, '--desktop-style', podir, '@INPUT@', '@OUTPUT@'],
     install : true,
     install_dir : join_paths(datadir, 'xsessions'),


### PR DESCRIPTION
## Description
Patch used on UB.

Lets only merge this once we find out why the xsession reverseDNS name format in git sometimes does / sometimes does not work

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
