### PR TITLE
Change label properties for notification bodies

### DIFF
--- a/src/daemon/notifications/popup.vala
+++ b/src/daemon/notifications/popup.vala
@@ -265,9 +265,11 @@ namespace Budgie.Notifications {
 				use_markup = true,
 				wrap = true,
 				wrap_mode = Pango.WrapMode.WORD_CHAR,
-				max_width_chars = 35,
-				halign = Gtk.Align.START,
+				width_chars = 33,
+				max_width_chars = 33,
+				lines = 2,
 				valign = Gtk.Align.START,
+				xalign = 0,
 				hexpand = true,
 				vexpand = true
 			};


### PR DESCRIPTION
## Description

This makes notification popup bodies more consistent, and prevents them from taking up unnecessarily large portions of the screen.

### Property Changes
The max chars were reduced slightly to ensure that the close button doesn't get shoved off the edge of the notification popup. Width chars were added so that the body text always has the same minimum and maximum size per line, so the entire popup body is filled by the label. Lines is set to 2, so only two lines of text is displayed. Note that this does not mean two lines in the popup; it's two lines of the actual notification text. This allows long lines to wrap (and wrapped lines don't count towards lines, because reasons) without popups taking up large amounts of screen real-estate. Xalign is set to 0 to ensure that the text always starts at the left (because halign and justify isn't enough).

### Screenshot

The top notification has a single long line that wraps, while the other consists of multiple lines.

![image](https://user-images.githubusercontent.com/5157277/186197065-9bdca358-3955-4186-af55-2f0e8b2445cb.png)

It would be great for people to try this branch out for a day (or several) before merging, so any concerns and tweaks can be addressed and made using actual day-to-day notifications.

Fixes #171

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
