### PR TITLE
Add missing gio-unix-2.0 dependencies

### DIFF
--- a/src/abomination/meson.build
+++ b/src/abomination/meson.build
@@ -8,6 +8,7 @@ libabomination_sources = [
 ]
 
 libabomination_deps = [
+    dep_giounix,
     dep_gtk3,
     dep_gdkx11,
     dep_wnck,

--- a/src/appindexer/meson.build
+++ b/src/appindexer/meson.build
@@ -11,6 +11,7 @@ libappindexer = shared_library(
     appindexer_sources,
     dependencies: [
         dep_gee,
+        dep_giounix,
         dep_gtk3,
     ],
     vala_args: [

--- a/src/applets/budgie-menu/meson.build
+++ b/src/applets/budgie-menu/meson.build
@@ -43,6 +43,7 @@ applet_budgiemenu_sources = [
 applet_budgiemenu_deps = [
     libplugin_vapi,
     dep_gee,
+    dep_giounix,
     dep_gtk3,
     dep_peas,
     dep_accountsservice,

--- a/src/applets/clock/meson.build
+++ b/src/applets/clock/meson.build
@@ -39,6 +39,7 @@ shared_library(
     applet_clock_sources,
     dependencies: [
         libplugin_vapi,
+        dep_giounix,
         dep_gtk3,
         dep_peas,
         link_libplugin,

--- a/src/applets/icon-tasklist/meson.build
+++ b/src/applets/icon-tasklist/meson.build
@@ -39,6 +39,7 @@ applet_icontasklist_sources = [
 
 applet_icontasklist_deps = [
     libplugin_vapi,
+    dep_giounix,
     dep_gtk3,
     dep_peas,
     dep_wnck,

--- a/src/applets/night-light/meson.build
+++ b/src/applets/night-light/meson.build
@@ -34,6 +34,7 @@ applet_nightlight_sources = [
 
 applet_nightlight_deps = [
     libplugin_vapi,
+    dep_giounix,
     dep_gtk3,
     dep_peas,
     link_libplugin,

--- a/src/applets/status/meson.build
+++ b/src/applets/status/meson.build
@@ -28,6 +28,7 @@ applet_status_sources = [
 
 applet_status_deps = [
     libplugin_vapi,
+    dep_giounix,
     dep_gtk3,
     dep_peas,
     dep_accountsservice,

--- a/src/applets/workspaces/meson.build
+++ b/src/applets/workspaces/meson.build
@@ -28,6 +28,7 @@ applet_workspaces_sources = [
 
 applet_workspaces_deps = [
     libplugin_vapi,
+    dep_giounix,
     dep_gtk3,
     dep_wnck,
     dep_peas,

--- a/src/appsys/meson.build
+++ b/src/appsys/meson.build
@@ -8,6 +8,7 @@ libappsys = static_library(
     'appsys',
     libappsys_sources,
     dependencies: [
+        dep_giounix,
         dep_gtk3,
         dep_gdkx11,
         dep_wnck,

--- a/src/daemon/meson.build
+++ b/src/daemon/meson.build
@@ -37,6 +37,7 @@ daemon_sources = [
 ]
 
 daemon_deps = [
+    dep_giounix,
     dep_gtk3,
     dep_gdkx11,
     dep_notify,

--- a/src/lib/meson.build
+++ b/src/lib/meson.build
@@ -14,6 +14,7 @@ libbudgieprivate = shared_library(
     dependencies: [
         libplugin_vapi,
         dep_peas,
+        dep_giounix,
         dep_gtk3,
         meson.get_compiler('c').find_library('m', required: false),
         link_libplugin,

--- a/src/libsession/meson.build
+++ b/src/libsession/meson.build
@@ -7,7 +7,10 @@ libsession_sources = [
 libsession = static_library(
     'session',
     libsession_sources,
-    dependencies: dep_glib,
+    dependencies: [
+        dep_glib,
+        dep_giounix
+    ],
     vala_args: [
         '--pkg', 'gio-unix-2.0',
     ],

--- a/src/panel/meson.build
+++ b/src/panel/meson.build
@@ -41,6 +41,7 @@ panel_sources = [
 
 panel_deps = [
     libplugin_vapi,
+    dep_giounix,
     dep_gtk3,
     dep_peas,
     dep_libuuid,

--- a/src/polkit/meson.build
+++ b/src/polkit/meson.build
@@ -24,6 +24,7 @@ polkit_sources = [
 pkversion = '>= 0.105'
 
 polkit_deps = [
+    dep_giounix,
     dep_gtk3,
     link_libconfig,
     link_libtheme,

--- a/src/raven/meson.build
+++ b/src/raven/meson.build
@@ -41,6 +41,7 @@ libraven_deps = [
     # https://github.com/mesonbuild/meson/issues/2096
     link_libbudgieprivate,
     libplugin_vapi,
+    dep_giounix,
     dep_gtk3,
     dep_peas,
     link_libconfig,

--- a/src/rundialog/meson.build
+++ b/src/rundialog/meson.build
@@ -4,6 +4,7 @@ rundialog_sources = [
 ]
 
 rundialog_deps = [
+    dep_giounix,
     dep_gtk3,
     link_libconfig,
     link_libtheme,

--- a/src/wm/meson.build
+++ b/src/wm/meson.build
@@ -33,6 +33,7 @@ endif
 
 budgie_wm_deps = [
     link_libconfig,
+    dep_giounix,
     dep_mutter,
     dep_gnomedesktop,
     dep_gsettings,


### PR DESCRIPTION
## Description

This commit adds all missing `gio-unix-2.0` dependencies on all targets that require it. This provides the `-I${PREFIX}/include/gio-unix-2.0` compiler flag, which fixes the following error:

![image](https://user-images.githubusercontent.com/62166915/187326522-82fc36ce-2ba5-4766-9cdf-6abd8062662d.png)

This issue was already reported to other projects by the NixOS community: https://github.com/NixOS/nixpkgs/issues/36468.

This patch can be applied to the tarball released with version 10.6.3: https://github.com/FedericoSchonborn/budgie-overlay/blob/f7b6e707d183fc3f8ee31efb923249252cb9910f/packages/budgie-desktop/0001-Add-missing-gio-unix-2.0-dependencies.patch (it omits the `appindexer` directory, which isn't included in release builds).

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
