### PR TITLE
Resolve numerous issues with the Workspace Applet

### DIFF
--- a/src/applets/workspaces/WorkspacesApplet.vala
+++ b/src/applets/workspaces/WorkspacesApplet.vala
@@ -226,7 +226,7 @@ namespace Workspaces {
 				}
 				Timeout.add(100, () => {
 					update_workspaces.begin();
-					return true;
+					return false;
 				});
 			}
 		}


### PR DESCRIPTION
## Description
Replaces a `return true` with a `return false` in a critical Timeout callback so the function isn't repeated every 100ms.

Fixes #184, #183, #182, and #180.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
