### PR TITLE
Add extra check in XDG dir detection

### DIFF
--- a/src/daemon/xdgdirtracker/dbus.vala
+++ b/src/daemon/xdgdirtracker/dbus.vala
@@ -66,7 +66,7 @@ namespace Budgie {
 				UserDirectory xdg_dir = xdg_dirs[i];
 				unowned string? path = Environment.get_user_special_dir(xdg_dir);
 
-				if (path == null) {
+				if (path == null || path == home_dir_file.get_path()) {
 					continue; // Skip this since the logical ID does not exist
 				}
 


### PR DESCRIPTION
## Description

For some reason, on Arch derivatives, XDG user dirs that aren't present or that resolve as symlinks are detected - but they resolve to the user's home dir instead. This compares the result of get_user_special_dir to the user's home dir path, and skips the XDG dir if they're equal.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
