### PR TITLE
Remove numeric space in formatted clock applet output

### DIFF
--- a/src/applets/clock/ClockApplet.vala
+++ b/src/applets/clock/ClockApplet.vala
@@ -323,7 +323,7 @@ public class ClockApplet : Budgie.Applet {
 			ftime = "<small>%s</small>";
 		}
 
-		var formatted = ftime.printf(ctime);
+		var formatted = ftime.printf(ctime).replace("\u2007", "");
 		if (old == formatted) {
 			return true;
 		}


### PR DESCRIPTION
This was introduced in the glib2 pull request [!2698](https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2698) and is not desired behavior for us.

## Description
Previous behavior restored by this PR:
![image](https://user-images.githubusercontent.com/12981608/192161252-fad5a35f-4a5e-4868-9f5b-5523aa5ee822.png)
Behavior introduced by the glib2 commit:
![image](https://user-images.githubusercontent.com/12981608/192161273-a3caee7e-534a-441e-9f26-cae6b331f20e.png)


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
