### PR TITLE
Allow Applications Icons to use fallbacks

### DIFF
--- a/src/appindexer/Application.vala
+++ b/src/appindexer/Application.vala
@@ -19,7 +19,7 @@ namespace Budgie {
 		public string desktop_id { get; construct set; }
 		public string exec { get; private set; }
 		public string[] keywords { get; private set;}
-		public Icon icon { get; private set; default = new ThemedIcon("application-default-icon"); }
+		public Icon icon { get; private set; default = new ThemedIcon.with_default_fallbacks("application-default-icon"); }
 		public string desktop_path { get; private set; }
 		public string categories { get; private set; }
 		public string generic_name { get; private set; default = ""; }


### PR DESCRIPTION
## Description
ThemedIcon can return invalid icons; this PR ensures fallbacks are used to prevent missing icon displays.
Closes: #205


### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
