### PR TITLE
Use idle and menu popup to display a Wnck ActionMenu

### DIFF
--- a/src/daemon/menus.vala
+++ b/src/daemon/menus.vala
@@ -119,7 +119,7 @@ namespace Budgie {
 				if (desktop_menu.get_visible()) {
 					desktop_menu.hide();
 				} else {
-					desktop_menu.popup_at_pointer(null);
+					popup_menu(desktop_menu, button, timestamp);
 				}
 				return false;
 			});
@@ -138,11 +138,15 @@ namespace Budgie {
 			Idle.add(() => {
 				action_menu = new Wnck.ActionMenu(active_window);
 				action_menu.show_all();
-				action_menu.popup(null,null,null,0,Gtk.get_current_event_time());
+				popup_menu(action_menu, button, timestamp);
 				return false;
 			});
 
 			this.xid = xid;
+		}
+
+		private void popup_menu(Gtk.Menu menu, uint button, uint32 timestamp) {
+			menu.popup(null, null, null, button, timestamp == 0 ? Gdk.CURRENT_TIME : timestamp);
 		}
 	}
 }

--- a/src/daemon/menus.vala
+++ b/src/daemon/menus.vala
@@ -131,10 +131,17 @@ namespace Budgie {
 		public void ShowWindowMenu(uint32 xid, uint button, uint32 timestamp) throws DBusError, IOError {
 			active_window = Wnck.Window.get(xid);
 			if (active_window == null) {
+				warning("invalid active_window");
 				return;
 			}
-			action_menu = new Wnck.ActionMenu(active_window);
-			action_menu.popup_at_pointer(null);
+
+			Idle.add(() => {
+				action_menu = new Wnck.ActionMenu(active_window);
+				action_menu.show_all();
+				action_menu.popup(null,null,null,0,Gtk.get_current_event_time());
+				return false;
+			});
+
 			this.xid = xid;
 		}
 	}


### PR DESCRIPTION
## Description
Draft - makes the window actionmenu display for most windows.

https://github.com/BuddiesOfBudgie/budgie-desktop/issues/176

Note - it uses the now deprecated Gtk.Menu.popup - I haven't figured out how to use one of the recommended alternatives.

ActionMenu doesn't appear on all windows - for example firefox esr or visual code (snap?)

We should also perhaps investigate removing the move workspace left/right menu items - should be able to-do that via the Gtk.Container remove methods at a guess. Remember the Wnck.ActionMenu is just a Gtk.Menu object

Anyway - marking this as draft.  **Feel free to improve** and eventually mark as ready.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
