### PR TITLE
update copyright notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ The remainder of the project (i.e. installed binaries) is available under the te
 
 ## Authors
 
-Copyright © 2014-2021 Budgie Desktop Developers
+Copyright © 2014-2022 Budgie Desktop Developers
 
 See our [contributors graph](https://github.com/BuddiesOfBudgie/budgie-desktop/graphs/contributors)!


### PR DESCRIPTION
This was randomly irritating me so here I am. Unless there's some reason why it should be left at 2021, which there very well could be.