### PR TITLE
Check for existence of desktop-directories dir in appindexer

### DIFF
--- a/src/appindexer/AppIndex.vala
+++ b/src/appindexer/AppIndex.vala
@@ -258,6 +258,11 @@ namespace Budgie {
 			var path = Path.build_path(Path.DIR_SEPARATOR_S, Environment.get_home_dir(), ".local", "share", "desktop-directories");
 			var directory_file = File.new_for_path(path);
 
+			// desktop-directories dir doesn't exist, skip custom categories
+			if (!directory_file.query_exists()) {
+				return;
+			}
+
 			try {
 				// Enumerate all of the files in the desktop-directories dir
 				var children = directory_file.enumerate_children(FileAttribute.STANDARD_NAME, FileQueryInfoFlags.NONE, null);


### PR DESCRIPTION
## Description

Before attempting to enumerate `~/.local/share/desktop-directories`, check to make sure it actually exists. Resolves #232.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
