### PR TITLE
Implement CI for armv7h, aarch64, and riscv64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,8 @@ jobs:
       with:
         arch: ${{ matrix.arch }}
         distro: ${{ matrix.distro }}
-        run: sudo apt update
-        run: sudo apt install meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
-        run: meson build -Dwith-gnome-screensaver=true
-        run: meson compile -C build
+        run: |
+          sudo apt update
+          sudo apt install meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
+          meson build -Dwith-gnome-screensaver=true
+          meson compile -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: sudo apt-get update -q -y
-    - run: sudo apt-get install -q -y meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
+    - run: sudo apt-get install -q -y meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac libxml2-utils
     - run: meson build -Dwith-gnome-screensaver=true
     - run: meson compile -C build
 
@@ -40,7 +40,7 @@ jobs:
 
         install: |
           apt-get update -q -y
-          apt-get install -q -y git meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
+          apt-get install -q -y git meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac libxml2-utils
         run: |
           git config --global --add safe.directory "$PWD"
           git submodule init

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,21 +18,28 @@ jobs:
     - run: meson build -Dwith-gnome-screensaver=true
     - run: meson compile -C build
 
-  aarch64:
+  extra-architectures:
     runs-on: ubuntu-22.04
+    name: ${{ matrix.arch }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [armv7, aarch64, riscv64]
+
     steps:
     - uses: actions/checkout@v3
     - uses: uraimo/run-on-arch-action@v2
       with:
-        arch: aarch64
+        arch: ${{ matrix.arch }}
         distro: ubuntu22.04
+        install: |
+          apt-get update -q -y
+          apt-get install -q -y git meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
         run: |
-          apt update -qq -y
-          apt install -qq -y git
           git config --global --add safe.directory "$PWD"
           git submodule init
           git submodule update
 
-          apt install -qq -y meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
           meson build -Dwith-gnome-screensaver=true
           meson compile -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,36 +10,24 @@ on:
     - v10.6.x
 jobs:
   amd64:
-    name: amd64
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - run: sudo apt update
-    - run: sudo apt install meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
+    - run: apt update
+    - run: apt install meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
     - run: meson build -Dwith-gnome-screensaver=true
     - run: meson compile -C build
 
-  extra:
-    name: ${{ matrix.arch }}
-    runs-on: ubuntu-22.04
-
-    # Run steps on a matrix of 4 arch/distro combinations
-    strategy:
-      matrix:
-        include:
-          - arch: armv7
-            distro: ubuntu22.04
-          - arch: aarch64
-            distro: ubuntu22.04
-
+  aarch64:
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
     - uses: uraimo/run-on-arch-action@v2
       with:
-        arch: ${{ matrix.arch }}
-        distro: ${{ matrix.distro }}
+        arch: aarch64
+        distro: ubuntu22.04
         run: |
-          sudo apt update
-          sudo apt install meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
+          apt update -q -y
+          apt install -q -y meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
           meson build -Dwith-gnome-screensaver=true
           meson compile -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,9 @@ on:
     - v10.6.x
 
 jobs:
-  ubuntu-amd64:
+  ubuntu:
     runs-on: ubuntu-22.04
+    name: Ubuntu
     steps:
     - uses: actions/checkout@v3
     - run: sudo apt-get update -q -y

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,11 @@ jobs:
         distro: ubuntu22.04
         run: |
           apt update -qq -y
-          apt install -qq -y git meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
+          apt install -qq -y git
+          git config --global --add safe.directory "$PWD"
           git submodule init
           git submodule update
+
+          apt install -qq -y meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
           meson build -Dwith-gnome-screensaver=true
           meson compile -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build on Ubuntu 22.04
+name: Ubuntu 22.04
 on:
   push:
     branches:
@@ -10,7 +10,7 @@ on:
     - v10.6.x
 jobs:
   amd64:
-    name: Build on amd64
+    name: amd64
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
@@ -20,14 +20,14 @@ jobs:
     - run: meson compile -C build
 
   extra:
-    name: Build on ${{ matrix.arch }}
+    name: ${{ matrix.arch }}
     runs-on: ubuntu-22.04
 
     # Run steps on a matrix of 4 arch/distro combinations
     strategy:
       matrix:
         include:
-          - arch: armv7h
+          - arch: armv7
             distro: ubuntu22.04
           - arch: aarch64
             distro: ubuntu22.04
@@ -38,7 +38,7 @@ jobs:
       with:
         arch: ${{ matrix.arch }}
         distro: ${{ matrix.distro }}
-    - run: sudo apt update
-    - run: sudo apt install meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
-    - run: meson build -Dwith-gnome-screensaver=true
-    - run: meson compile -C build
+        run: sudo apt update
+        run: sudo apt install meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
+        run: meson build -Dwith-gnome-screensaver=true
+        run: meson compile -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - run: apt update
-    - run: apt install meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
+    - run: sudo apt update
+    - run: sudo apt install meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
     - run: meson build -Dwith-gnome-screensaver=true
     - run: meson compile -C build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,35 @@ on:
     - master
     - v10.6.x
 jobs:
-  ubuntu:
+  amd64:
+    name: Build on amd64
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+    - run: sudo apt update
+    - run: sudo apt install meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
+    - run: meson build -Dwith-gnome-screensaver=true
+    - run: meson compile -C build
+
+  extra:
+    name: Build on ${{ matrix.arch }}
+    runs-on: ubuntu-22.04
+
+    # Run steps on a matrix of 4 arch/distro combinations
+    strategy:
+      matrix:
+        include:
+          - arch: armv7h
+            distro: ubuntu22.04
+          - arch: aarch64
+            distro: ubuntu22.04
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: uraimo/run-on-arch-action@v2
+      with:
+        arch: ${{ matrix.arch }}
+        distro: ${{ matrix.distro }}
     - run: sudo apt update
     - run: sudo apt install meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
     - run: meson build -Dwith-gnome-screensaver=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - run: meson compile -C build
 
   aarch64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: uraimo/run-on-arch-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,9 @@ jobs:
         arch: aarch64
         distro: ubuntu22.04
         run: |
-          apt update -q -y
-          apt install -q -y meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
+          apt update -qq -y
+          apt install -qq -y git meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
+          git submodule init
+          git submodule update
           meson build -Dwith-gnome-screensaver=true
           meson compile -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 22.04
+name: Build
 on:
   push:
     branches:
@@ -8,19 +8,20 @@ on:
     branches:
     - master
     - v10.6.x
+
 jobs:
-  amd64:
+  ubuntu-amd64:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - run: sudo apt update
-    - run: sudo apt install meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
+    - run: sudo apt-get update -q -y
+    - run: sudo apt-get install -q -y meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac
     - run: meson build -Dwith-gnome-screensaver=true
     - run: meson compile -C build
 
   extra-architectures:
     runs-on: ubuntu-22.04
-    name: ${{ matrix.arch }}
+    name: Ubuntu (${{ matrix.arch }})
 
     strategy:
       fail-fast: false
@@ -33,6 +34,10 @@ jobs:
       with:
         arch: ${{ matrix.arch }}
         distro: ubuntu22.04
+
+        # not strictly necessary, but caches dependencies for faster builds
+        githubToken: ${{ github.token }}
+
         install: |
           apt-get update -q -y
           apt-get install -q -y git meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac


### PR DESCRIPTION
## Description

Adds stages to the CI workflow for armv7, aarch64 (armv8), and riscv64. All build on Ubuntu 22.04. The repository configuration will need to be updated to require the newly updated checks.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
