### PR TITLE
Queue resize of workspace item after size mult changed

### DIFF
--- a/src/applets/workspaces/WorkspacesApplet.vala
+++ b/src/applets/workspaces/WorkspacesApplet.vala
@@ -223,6 +223,7 @@ namespace Workspaces {
 					Gtk.Revealer revealer = widget as Gtk.Revealer;
 					WorkspaceItem item = revealer.get_child() as WorkspaceItem;
 					item.set_size_multiplier(item_size_multiplier);
+					item.queue_resize();
 				}
 				Timeout.add(100, () => {
 					update_workspaces.begin();


### PR DESCRIPTION
## Description

The workspaces applet currently delays its refresh of the workspace item grid layout too late after the item size multiplier setting is changed, as seen here:

https://user-images.githubusercontent.com/12981608/209994673-fc4ae814-4f56-45b3-b04a-936592bedcc1.mp4

This patch queues a resize of each workspace item after the setting is changed, which allows for each item to refresh its grid properly, as seen here:

https://user-images.githubusercontent.com/12981608/209994794-91b2f7a1-1311-47b5-91c3-b5e5f95913ab.mp4


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
