### PR TITLE
Fix orientation with dual batteries

### DIFF
--- a/src/applets/status/PowerIndicator.vala
+++ b/src/applets/status/PowerIndicator.vala
@@ -213,6 +213,7 @@ public class PowerIndicator : Gtk.Bin {
 			icon.set_spacing(spacing);
 			icon.set_orientation(orient);
 		}
+		widget.set_orientation(orient);
 	}
 
 	private void update_labels() {
@@ -266,6 +267,7 @@ public class PowerIndicator : Gtk.Bin {
 		icon.label_visible = this.label_visible;
 		devices.insert(object_path, icon);
 		widget.pack_start(icon);
+		change_orientation(widget.get_orientation());
 		toggle_show();
 	}
 


### PR DESCRIPTION
## Description

Fixes  #245

Fix issues with battery indicators on vertical panels. (Fixes 

- Fixes the orientation of the battery icons / labels so that on a left/right panel, a system with multiple batteries (i.e. a laptop with an internal and external battery) will display them vertically instead of horizontally. (avoiding an issue which causes the panel to expand beyond its expected size.

- Fixes an issue where if a 2nd battery is added to the system after the panel is running, the percentage label is displayed to the left of the icon instead of above it.

![panel3](https://user-images.githubusercontent.com/67085765/210252915-7f676b1a-5267-46b5-bd91-399a1c4df660.png)


### Submitter Checklist

- [ x ] Squashed commits with `git rebase -i` (if needed)
- [ x ] Built budgie-desktop and verified that the patch worked (if needed)
