### PR TITLE
Set menu icon including where icon themes do not have a default

### DIFF
--- a/src/appindexer/Application.vala
+++ b/src/appindexer/Application.vala
@@ -64,7 +64,7 @@ namespace Budgie {
 			if (desktop_icon != null) {
 				// Make sure we have a usable icon
 				unowned var theme = Gtk.IconTheme.get_default();
-				if (theme.lookup_by_gicon(this.icon, 64, Gtk.IconLookupFlags.USE_BUILTIN) != null) {
+				if (theme.lookup_by_gicon(desktop_icon, 64, Gtk.IconLookupFlags.USE_BUILTIN) != null) {
 					this.icon = desktop_icon;
 				}
 			}


### PR DESCRIPTION
## Description
Some icon-themes do not have a application-default-icon defined.

Due to a quirk of fate our menu icon handling code was only testing
if the application icon "application-default-icon" was in the theme before
displaying it.

This PR now updates the logic to calculate if the application icon itself
is in the icon theme.

Verified using Moka icon theme 

1. Without the patch, using Moka and restarting the panel or logout/login the menu icons showed an empty icon
2. With the patch, Moka icons displayed correctly.  Even where Moka icons did not exist, the default application icon is displayed.

Note - we already set the application-default-icon fallback here https://github.com/BuddiesOfBudgie/budgie-desktop/blob/0eea3fdd3b1d98dbcd8699c8611bade46fe7a9f3/src/appindexer/Application.vala#L22

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
