### PR TITLE
Disable Hibernation button if the system doesn't support it

### DIFF
--- a/src/dialogs/power/dbus.vala
+++ b/src/dialogs/power/dbus.vala
@@ -27,6 +27,8 @@ namespace Budgie {
 	/* logind */
 	[DBus (name="org.freedesktop.login1.Manager")]
 	public interface LogindRemote : Object {
+		public abstract string can_hibernate() throws DBusError, IOError;
+
 		public abstract void suspend(bool interactive) throws DBusError, IOError;
 		public abstract void hibernate(bool interactive) throws DBusError, IOError;
 	}

--- a/src/dialogs/power/window.vala
+++ b/src/dialogs/power/window.vala
@@ -145,6 +145,12 @@ namespace Budgie {
 				return Gdk.EVENT_STOP;
 			});
 
+			show.connect(() => {
+				var can_hibernate = can_hibernate();
+				hibernate_button.sensitive = can_hibernate;
+				hibernate_button.set_tooltip_markup(can_hibernate ? null : _("This system does not support hibernation."));
+			});
+
 			event_controller = new EventControllerKey(this);
 			event_controller.key_released.connect(on_key_release);
 		}
@@ -216,6 +222,16 @@ namespace Budgie {
 				}
 				return false;
 			});
+		}
+
+		private bool can_hibernate() {
+			var can_hibernate = true;
+			try {
+				can_hibernate = logind.can_hibernate() == "yes";
+			} catch (Error e) {
+				warning("Failed to check if hibernation is supported: %s", e.message);
+			}
+			return can_hibernate;
 		}
 
 		private void hibernate() {


### PR DESCRIPTION
## Description

logind provides a method of detecting if hibernation is enabled on a system. This PR adds a check to the power dialog code that sets the sensitivity of the hibernation button conditional on whether hibernation is supported. Additionally, if hibernation is not supported, a tooltip is added to the button on hover that explains why the button is disabled.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
