### PR TITLE
Add new default menu icon

### DIFF
--- a/data/icons/README
+++ b/data/icons/README
@@ -1,3 +1,6 @@
+The budgie-menu-symbolic.svg file was created by Campbell Jones and is
+licensed under the CC0 1.0 license
+
 The notification-alert-symbolic.svg file is a modification of an
 icon found on 1001freedownloads, under the CC0 1.0 license
 

--- a/data/icons/actions/budgie-menu-symbolic.svg
+++ b/data/icons/actions/budgie-menu-symbolic.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="32" height="32" version="1.1" viewBox="0 0 8.5 8.5" xmlns="http://www.w3.org/2000/svg">
+ <g fill="#eee">
+  <rect x="1.6" y="1.6" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="3.7" y="1.6" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="5.8" y="1.6" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="1.6" y="3.7" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="3.7" y="3.7" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="5.8" y="3.7" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="1.6" y="5.8" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="3.7" y="5.8" width="1.1" height="1.1" rx=".16" ry=".16"/>
+  <rect x="5.8" y="5.8" width="1.1" height="1.1" rx=".16" ry=".16"/>
+ </g>
+</svg>

--- a/data/meson.build
+++ b/data/meson.build
@@ -11,6 +11,7 @@ version_file = configure_file(
 )
 
 actions_icons = [
+    join_paths('.', 'icons', 'actions', 'budgie-menu-symbolic.svg'),
     join_paths('.', 'icons', 'actions', 'notification-alert-symbolic.svg'),
     join_paths('.', 'icons', 'actions', 'notification-disabled-symbolic.svg'),
     join_paths('.', 'icons', 'actions', 'pane-hide-symbolic.svg'),

--- a/src/panel/applets/budgie-menu/BudgieMenu.vala
+++ b/src/panel/applets/budgie-menu/BudgieMenu.vala
@@ -77,6 +77,7 @@ public class BudgieMenuApplet : Budgie.Applet {
 	protected Gtk.ToggleButton widget;
 	protected BudgieMenuWindow? popover;
 	protected Settings settings;
+	private Settings ui_settings;
 	Gtk.Image img;
 	Gtk.Label label;
 	Budgie.PanelPosition panel_position = Budgie.PanelPosition.BOTTOM;
@@ -103,8 +104,14 @@ public class BudgieMenuApplet : Budgie.Applet {
 		settings_prefix = "/com/solus-project/budgie-panel/instance/budgie-menu";
 
 		settings = this.get_applet_settings(uuid);
-
 		settings.changed.connect(on_settings_changed);
+
+		ui_settings = new Settings("org.gnome.desktop.interface");
+		ui_settings.changed.connect((key) => {
+			if (key == "icon-theme") {
+				on_settings_changed("menu-icon");
+			}
+		});
 
 		app_index = Budgie.AppIndex.@get();
 
@@ -221,7 +228,7 @@ public class BudgieMenuApplet : Budgie.Applet {
 			case "use-default-menu-icon":
 			case "menu-icon":
 				string? icon;
-				if (settings.get_boolean("use-default-menu-icon")) {
+				if (settings.get_boolean("use-default-menu-icon") || start_here_icon_is_gnome_foot()) {
 					icon = "budgie-menu-symbolic";
 				} else {
 					icon = settings.get_string("menu-icon");
@@ -258,6 +265,12 @@ public class BudgieMenuApplet : Budgie.Applet {
 			default:
 				break;
 		}
+	}
+
+	private bool start_here_icon_is_gnome_foot() {
+		var theme_name = ui_settings.get_string("icon-theme");
+		return theme_name == "" || theme_name == "default" || theme_name == "Adwaita" ||
+			theme_name == "hicolor" || theme_name == "HighContrast";
 	}
 
 	public override void update_popovers(Budgie.PopoverManager? manager) {

--- a/src/panel/applets/budgie-menu/BudgieMenu.vala
+++ b/src/panel/applets/budgie-menu/BudgieMenu.vala
@@ -36,6 +36,9 @@ public class BudgieMenuSettings : Gtk.Grid {
 	private unowned Gtk.Entry? entry_label;
 
 	[GtkChild]
+	private unowned Gtk.Switch? switch_use_default_icon;
+
+	[GtkChild]
 	private unowned Gtk.Entry? entry_icon_pick;
 
 	[GtkChild]
@@ -50,6 +53,7 @@ public class BudgieMenuSettings : Gtk.Grid {
 		settings.bind("menu-headers", switch_menu_headers, "active", SettingsBindFlags.DEFAULT);
 		settings.bind("menu-categories-hover", switch_menu_categories_hover, "active", SettingsBindFlags.DEFAULT);
 		settings.bind("menu-label", entry_label, "text", SettingsBindFlags.DEFAULT);
+		settings.bind("use-default-menu-icon", switch_use_default_icon, "active", SettingsBindFlags.DEFAULT);
 		settings.bind("menu-icon", entry_icon_pick, "text", SettingsBindFlags.DEFAULT);
 		settings.bind("menu-show-control-center-items", switch_menu_show_settings_items, "active", SettingsBindFlags.DEFAULT);
 
@@ -171,6 +175,7 @@ public class BudgieMenuApplet : Budgie.Applet {
 		valign = Gtk.Align.FILL;
 		halign = Gtk.Align.FILL;
 		on_settings_changed("enable-menu-label");
+		on_settings_changed("use-default-menu-icon");
 		on_settings_changed("menu-icon");
 		on_settings_changed("menu-label");
 
@@ -213,15 +218,22 @@ public class BudgieMenuApplet : Budgie.Applet {
 		bool should_show = true;
 
 		switch (key) {
+			case "use-default-menu-icon":
 			case "menu-icon":
-				string? icon = settings.get_string(key);
+				string? icon;
+				if (settings.get_boolean("use-default-menu-icon")) {
+					icon = "budgie-menu-symbolic";
+				} else {
+					icon = settings.get_string("menu-icon");
+				}
+
 				if ("/" in icon) {
 					try {
 						Gdk.Pixbuf pixbuf = new Gdk.Pixbuf.from_file(icon);
 						img.set_from_pixbuf(pixbuf.scale_simple(this.pixel_size, this.pixel_size, Gdk.InterpType.BILINEAR));
 					} catch (Error e) {
 						warning("Failed to update Budgie Menu applet icon: %s", e.message);
-						img.set_from_icon_name("view-grid-symbolic", Gtk.IconSize.INVALID); // Revert to view-grid-symbolic
+						img.set_from_icon_name("start-here-symbolic", Gtk.IconSize.INVALID); // Revert to start-here-symbolic
 					}
 				} else if (icon == "") {
 					should_show = false;

--- a/src/panel/applets/budgie-menu/com.solus-project.budgie-menu.gschema.xml
+++ b/src/panel/applets/budgie-menu/com.solus-project.budgie-menu.gschema.xml
@@ -14,6 +14,12 @@
       <description>The menu label to display on the menu button</description>
     </key>
 
+    <key type="b" name="use-default-menu-icon">
+      <default>true</default>
+      <summary>Use Default Menu Icon</summary>
+      <description>Use the default icon for the menu button</description>
+    </key>
+
     <key type="s" name="menu-icon">
       <default>'start-here-symbolic'</default>
       <summary>Menu button icon</summary>

--- a/src/panel/applets/budgie-menu/com.solus-project.budgie-menu.gschema.xml
+++ b/src/panel/applets/budgie-menu/com.solus-project.budgie-menu.gschema.xml
@@ -15,7 +15,7 @@
     </key>
 
     <key type="b" name="use-default-menu-icon">
-      <default>true</default>
+      <default>false</default>
       <summary>Use Default Menu Icon</summary>
       <description>Use the default icon for the menu button</description>
     </key>

--- a/src/panel/applets/budgie-menu/settings.ui
+++ b/src/panel/applets/budgie-menu/settings.ui
@@ -8,14 +8,14 @@
     <property name="icon-name">folder-open</property>
     <property name="icon_size">1</property>
   </object>
-  <!-- n-columns=3 n-rows=7 -->
+  <!-- n-columns=2 n-rows=8 -->
   <template class="BudgieMenuSettings" parent="GtkGrid">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="row-spacing">10</property>
     <property name="column-spacing">6</property>
     <child>
-      <object class="GtkLabel" id="label1">
+      <object class="GtkLabel" id="label0">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="halign">start</property>
@@ -40,55 +40,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkLabel" id="label3">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="halign">start</property>
-        <property name="label" translatable="yes">Compact Mode</property>
-      </object>
-      <packing>
-        <property name="left-attach">0</property>
-        <property name="top-attach">3</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkSwitch" id="switch_menu_compact">
-        <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <property name="halign">end</property>
-        <property name="hexpand">True</property>
-      </object>
-      <packing>
-        <property name="left-attach">1</property>
-        <property name="top-attach">3</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="label4">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="halign">start</property>
-        <property name="label" translatable="yes">Show Headers</property>
-      </object>
-      <packing>
-        <property name="left-attach">0</property>
-        <property name="top-attach">4</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkSwitch" id="switch_menu_headers">
-        <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <property name="halign">end</property>
-        <property name="hexpand">True</property>
-      </object>
-      <packing>
-        <property name="left-attach">1</property>
-        <property name="top-attach">4</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="label2">
+      <object class="GtkLabel" id="label1">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="halign">start</property>
@@ -113,19 +65,19 @@
       </packing>
     </child>
     <child>
-      <object class="GtkLabel" id="label5">
+      <object class="GtkLabel" id="label2">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="halign">start</property>
-        <property name="label" translatable="yes">Roll-over mouse</property>
+        <property name="label" translatable="yes">Use Default Menu Icon</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">5</property>
+        <property name="top-attach">2</property>
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="switch_menu_categories_hover">
+      <object class="GtkSwitch" id="switch_use_default_icon">
         <property name="visible">True</property>
         <property name="can-focus">True</property>
         <property name="halign">end</property>
@@ -133,11 +85,11 @@
       </object>
       <packing>
         <property name="left-attach">1</property>
-        <property name="top-attach">5</property>
+        <property name="top-attach">2</property>
       </packing>
     </child>
     <child>
-      <object class="GtkLabel" id="label6">
+      <object class="GtkLabel" id="label3">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="halign">start</property>
@@ -146,7 +98,7 @@
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">2</property>
+        <property name="top-attach">3</property>
       </packing>
     </child>
     <child>
@@ -185,7 +137,79 @@
       </object>
       <packing>
         <property name="left-attach">1</property>
-        <property name="top-attach">2</property>
+        <property name="top-attach">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label4">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Compact Mode</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">4</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="switch_menu_compact">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="halign">end</property>
+        <property name="hexpand">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">4</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label5">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Show Headers</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">5</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="switch_menu_headers">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="halign">end</property>
+        <property name="hexpand">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">5</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label6">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Roll-over mouse</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">6</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="switch_menu_categories_hover">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="halign">end</property>
+        <property name="hexpand">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">6</property>
       </packing>
     </child>
     <child>
@@ -198,7 +222,7 @@
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">6</property>
+        <property name="top-attach">7</property>
       </packing>
     </child>
     <child>
@@ -210,29 +234,8 @@
       </object>
       <packing>
         <property name="left-attach">1</property>
-        <property name="top-attach">6</property>
+        <property name="top-attach">7</property>
       </packing>
-    </child>
-    <child>
-      <placeholder/>
-    </child>
-    <child>
-      <placeholder/>
-    </child>
-    <child>
-      <placeholder/>
-    </child>
-    <child>
-      <placeholder/>
-    </child>
-    <child>
-      <placeholder/>
-    </child>
-    <child>
-      <placeholder/>
-    </child>
-    <child>
-      <placeholder/>
     </child>
   </template>
   <object class="GtkSizeGroup" id="szgrp_entries">


### PR DESCRIPTION
## Description

This pull request adds a new symbolic menu icon made from scratch. This new icon is only used if the user enables the new "Use Default Menu Icon" option in the Budgie Menu applet settings, or if the currently selected icon theme is in the following list: `["", "Adwaita", "HighContrast", "hicolor", "default"]`. 

The new icon was fully made from scratch using Inkscape. I've elected to license it under CC0 v1.0, and have mentioned this in the icons folder's README.

**New Icon**
![image](https://user-images.githubusercontent.com/12981608/158456108-8a112c5a-7002-4ef2-aa8c-9279ca6ade16.png)

**Papirus**
![image](https://user-images.githubusercontent.com/12981608/158456238-ef377b5c-3f88-4d46-b3c4-79f39446039e.png)

**Paper**
![image](https://user-images.githubusercontent.com/12981608/158456316-17b10105-b4a4-443c-807e-af4d53609c20.png)

**hicolor**
![image](https://user-images.githubusercontent.com/12981608/158456493-7f334fd9-4a60-4e4a-924d-6b67ee0353a2.png)

Resolves #10.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
