### PR TITLE
Respect OnlyShowIn in Budgie Menu

### DIFF
--- a/src/appindexer/AppIndex.vala
+++ b/src/appindexer/AppIndex.vala
@@ -311,7 +311,7 @@ namespace Budgie {
 			// We have to make sure to add BCC panel items because they
 			// have NoDisplay set, so this would otherwise exclude them.
 			// Showing/hiding them is handled by the UI layer.
-			bool should_skip = (!app_info.should_show() && !is_control_center_panel) ||
+			bool should_skip = ((!app_info.should_show() || !app_info.get_show_in("Budgie")) && !is_control_center_panel) ||
 								(app_info.get_boolean("Terminal"));
 
 			if (should_skip) {

--- a/src/appindexer/Application.vala
+++ b/src/appindexer/Application.vala
@@ -56,7 +56,7 @@ namespace Budgie {
 			this.categories = app_info.get_categories();
 			this.generic_name = app_info.get_generic_name();
 			this.prefers_default_gpu = !app_info.get_boolean("PrefersNonDefaultGPU");
-			this.should_show = app_info.should_show();
+			this.should_show = app_info.should_show() && app_info.get_show_in("Budgie");
 			this.dbus_activatable = app_info.get_boolean("DBusActivatable");
 
 			// Try to get an icon from the desktop file


### PR DESCRIPTION
## Description

This adds a specific check to the Budgie Menu that avoids showing an application entry if it should not be shown in Budgie (for example, if the desktop file sets OnlyShowIn and excludes Budgie from the entries). The intent is to hide GNOME-specific software that should not be used on other desktop environments, primarily GNOME Control Center, as Budgie's XDG_CURRENT_DESKTOP is `Budgie:GNOME` for compatibility reasons. 

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
