### PR TITLE
Fix notification drop shadow

### DIFF
--- a/src/daemon/notifications/dbus.vala
+++ b/src/daemon/notifications/dbus.vala
@@ -110,7 +110,7 @@
 		private const string APPLICATION_PREFIX = "/org/gnome/desktop/notifications/application";
 
 		/** Spacing between notification popups */
-		private const int BUFFER_ZONE = 10;
+		private const int BUFFER_ZONE = 0;
 		/** Spacing between the first notification and the edge of the screen */
 		private const int INITIAL_BUFFER_ZONE = 45;
 		/** Maximum number of popups to show on the screen at once */

--- a/src/daemon/notifications/popup.vala
+++ b/src/daemon/notifications/popup.vala
@@ -69,6 +69,7 @@ namespace Budgie.Notifications {
 
 			var box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0) {
 				margin = 8,
+				margin_top = 2,
 			};
 			box.get_style_context().add_class("drop-shadow");
 			box.pack_start(overlay, true, true, 0);

--- a/src/daemon/notifications/popup.vala
+++ b/src/daemon/notifications/popup.vala
@@ -67,7 +67,9 @@ namespace Budgie.Notifications {
 			overlay.add(content_stack);
 			overlay.add_overlay(close_button);
 
-			var box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
+			var box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0) {
+				margin = 8,
+			};
 			box.get_style_context().add_class("drop-shadow");
 			box.pack_start(overlay, true, true, 0);
 


### PR DESCRIPTION
## Description

Fixes a regression from #222 where the drop shadow on notification popups was cut off by the window border.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
