### PR TITLE
Fix missing hide calls and item_clicked emit on overlay menu.

### DIFF
--- a/src/panel/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/src/panel/applets/budgie-menu/BudgieMenuWindow.vala
@@ -110,10 +110,12 @@ public class BudgieMenuWindow : Budgie.Popover {
 
 		this.system_settings_button.clicked.connect(() => {
 			this.open_desktop_entry("budgie-control-center.desktop");
+			this.hide();
 		});
 
 		this.budgie_desktop_prefs_button.clicked.connect(() => {
 			this.open_desktop_entry("org.buddiesofbudgie.BudgieDesktopSettings.desktop");
+			this.hide();
 		});
 
 		// Enabling activation by search entry

--- a/src/panel/applets/budgie-menu/OverlayMenus.vala
+++ b/src/panel/applets/budgie-menu/OverlayMenus.vala
@@ -75,7 +75,10 @@ public class OverlayMenus : Revealer {
 
 			val.set_data<UserDirectory>("user-directory", key); // Add the UserDirectory as the data for this button
 			this.folder_items.insert(val, -1); // Add each of the menu items
-			val.clicked.connect((val) => { this.handle_xdg_dir_clicked(val);});
+			val.clicked.connect((val) => {
+				this.handle_xdg_dir_clicked(val);
+				this.item_clicked();
+			});
 		});
 
 		this.setup_dbus.begin();


### PR DESCRIPTION
This PR adds function calls to hide Budgie Menu when clicking the Budgie Desktop Settings and System Settings buttons, as well as adding a missing item_clicked signal call in Overlay Menu for closure of Budgie Menu based on the connected function.
