### PR TITLE
Fix spacing in buttons in Budgie Menu overlay

### DIFF
--- a/src/panel/applets/budgie-menu/MenuItem.vala
+++ b/src/panel/applets/budgie-menu/MenuItem.vala
@@ -41,8 +41,8 @@ public class MenuItem : Gtk.Button {
 		this.set_image(image_source);
 		this.set_label(label_text);
 
-		this.menu_item = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 4);
-		this.menu_item.pack_start(this.button_image, false, false, 6);
+		this.menu_item = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 8);
+		this.menu_item.pack_start(this.button_image, false, false, 0);
 		this.menu_item.pack_end(this.button_label, true, true, 0);
 
 		this.add(this.menu_item);


### PR DESCRIPTION
## Description

Reduces the padding to the left of the icons in the Budgie Menu user dirs overlay.

### Before Patch

![image](https://user-images.githubusercontent.com/12981608/215185307-730aa1bf-fcda-46a4-a16d-db7354f91291.png)

### After Patch

![image](https://user-images.githubusercontent.com/12981608/215185101-477962a0-018b-4307-8985-b8660af76a0f.png)


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
