### PR TITLE
feat: Add option to turn off the playback of screenshot capture sound.

### DIFF
--- a/src/daemon/org.buddiesofbudgie.budgie-desktop.screenshot.gschema.xml
+++ b/src/daemon/org.buddiesofbudgie.budgie-desktop.screenshot.gschema.xml
@@ -6,7 +6,7 @@
             <summary>Screenshot delay</summary>
             <description>Number of seconds to wait before taking a screenshot</description>
             <default>0</default>
-	    <range min="0" max="30"/>
+            <range min="0" max="30"/>
         </key>
             <key type="s" name="screenshot-mode">
             <choices>
@@ -22,7 +22,7 @@
             <summary>Index of the last used directory</summary>
             <description>Index of the last used directory. If default user-dirs are there, index equals Enum from: UserDirectory https://valadoc.org/glib-2.0/GLib.UserDirectory.html. in case of index error, fallback is user home directory</description>
             <default>4</default>
-	    <range min="0" max="7"/>
+            <range min="0" max="7"/>
         </key>
         <key type="s" name="file-type">
             <choices>
@@ -38,17 +38,22 @@
         </key>
          <key type="b" name="include-frame">
             <summary>Include window frame in the screenshot</summary>
-            <description>Wether to include the window frame in the screenshot or not</description>
+            <description>Whether to include the window frame in the screenshot or not</description>
             <default>true</default>
         </key>
          <key type="b" name="showtooltips">
-            <summary>Wether to show tooltips</summary>
-            <description>Wether to show tooltips on headerbar buttons or not</description>
+            <summary>Whether to show tooltips</summary>
+            <description>Whether to show tooltips on headerbar buttons or not</description>
+            <default>true</default>
+        </key>
+         <key type="b" name="screenshot-capture-sound">
+            <summary>Whether to show emit a sound on screenshot capture</summary>
+            <description>Whether to show emit a sound on screenshot capture</description>
             <default>true</default>
         </key>
         <key type="b" name="include-cursor">
             <summary>Include the cursor in the screenshot</summary>
-            <description>Wether to include the cursor in the screenshot or not</description>
+            <description>Whether to include the cursor in the screenshot or not</description>
             <default>false</default>
         </key>
     </schema>

--- a/src/daemon/org.buddiesofbudgie.budgie-desktop.screenshot.gschema.xml
+++ b/src/daemon/org.buddiesofbudgie.budgie-desktop.screenshot.gschema.xml
@@ -47,8 +47,8 @@
             <default>true</default>
         </key>
          <key type="b" name="screenshot-capture-sound">
-            <summary>Whether to show emit a sound on screenshot capture</summary>
-            <description>Whether to show emit a sound on screenshot capture</description>
+            <summary>Whether to emit a sound on screenshot capture</summary>
+            <description>Whether to emit a sound on screenshot capture</description>
             <default>true</default>
         </key>
         <key type="b" name="include-cursor">

--- a/src/daemon/screenshot.vala
+++ b/src/daemon/screenshot.vala
@@ -209,7 +209,6 @@ namespace BudgieScr {
 			}
 		}
 
-
 		async void shoot_window() {
 			bool success = false;
 			string filename_used = "";
@@ -385,10 +384,10 @@ namespace BudgieScr {
 			maingrid.attach(areabuttonbox, 0, 0, 1, 1);;
 
 			// show pointer
-			windowstate.screenshot_settings.bind("include-cursor", showpointerswitch, "active",	SettingsBindFlags.GET|SettingsBindFlags.SET);
+			windowstate.screenshot_settings.bind("include-cursor", showpointerswitch, "active", SettingsBindFlags.GET|SettingsBindFlags.SET);
 
 			// screenshot capture sound
-			windowstate.screenshot_settings.bind("screenshot-capture-sound", screenshotcapturesoundswitch, "active",	SettingsBindFlags.GET|SettingsBindFlags.SET);
+			windowstate.screenshot_settings.bind("screenshot-capture-sound", screenshotcapturesoundswitch, "active", SettingsBindFlags.GET|SettingsBindFlags.SET);
 
 			// delay
 			windowstate.screenshot_settings.bind("delay", delayspin, "value", SettingsBindFlags.GET|SettingsBindFlags.SET);

--- a/src/daemon/screenshothome.ui
+++ b/src/daemon/screenshothome.ui
@@ -75,7 +75,7 @@
           </object>
           <packing>
             <property name="left-attach">0</property>
-            <property name="top-attach">3</property>
+            <property name="top-attach">4</property>
           </packing>
         </child>
         <child>
@@ -126,6 +126,56 @@
           <packing>
             <property name="left-attach">0</property>
             <property name="top-attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="screenshotcapturesoundbox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkLabel" id="screenshotcapturesoundlabel">
+                <property name="width-request">290</property>
+                <property name="height-request">10</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label">Play sound when capturing</property>
+                <property name="xalign">0</property>
+                <style>
+                  <class name="optionslabel"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <!-- n-columns=1 n-rows=1 -->
+              <object class="GtkGrid" id="screenshotcapturesoundgrid">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkSwitch" id="screenshotcapturesoundswitch">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">3</property>
           </packing>
         </child>
         <child>


### PR DESCRIPTION
The sound can be quite loud compared to other application and system volumes, as I discovered yesterday when streaming release write-up. So let's have an option to have silent capture.

Also fixes some inconsistent alignment / indentation in the gschema.
