### PR TITLE
Ensure screenshot popover labels match their corresponding keyboard shortcut

### DIFF
--- a/src/daemon/screenshot.vala
+++ b/src/daemon/screenshot.vala
@@ -436,8 +436,8 @@ namespace BudgieScr {
 			Label[] shortcutnames = {
 				// Translators: be as brief as possible; popovers ar cut off if broader than the window
 				new Label(_("Screenshot entire screen") + ":\t"),
-				new Label(_("Screenshot selected area") + ":\t"),
 				new Label(_("Screenshot active window") + ":\t"),
+				new Label(_("Screenshot selected area") + ":\t"),
 			};
 
 			shortcutlabels = {};


### PR DESCRIPTION

## Description
This is a case of not cleaning one's glasses during implementation.

The screenshot window "..." shows the current keyboard shortcuts ... except the area and window labels are the wrong way around.  This PR switches around the labels.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
