### PR TITLE
feat: Automatically update Calendar widget when showing Raven.

### DIFF
--- a/src/panel/applets/notifications/NotificationsApplet.vala
+++ b/src/panel/applets/notifications/NotificationsApplet.vala
@@ -81,7 +81,7 @@ public class NotificationsApplet : Budgie.Applet {
 			raven_proxy.ReadNotifications.connect(on_notifications_read);
 			raven_proxy.GetNotificationCount.begin(on_get_count);
 		} catch (Error e) {
-			warning("Failed to gain Raven proxy: %s", e.message);
+			warning("Failed to get Raven proxy: %s", e.message);
 		}
 	}
 


### PR DESCRIPTION
This PR introduces an update to our Calendar widget that eliminates an unnecessary 30 second timer that existed for the purposes of highlighting the current day. Instead, we just listen for the ExpansionChanged event from Raven and when we know Raven is open, update it then.