### PR TITLE
Test if the window of type desktop before taking a window screenshot.

### DIFF
--- a/src/wm/screenshot.vala
+++ b/src/wm/screenshot.vala
@@ -133,6 +133,11 @@ namespace Budgie {
 				throw new DBusError.FAILED("Cannot find active window");
 			}
 
+			if (window.get_window_type() == Meta.WindowType.DESKTOP) {
+				yield screenshot(include_cursor, flash, filename, out success, out filename_used);
+				return;
+			}
+
 			var window_actor = (Meta.WindowActor) window.get_compositor_private();
 
 			float actor_x, actor_y;


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/996240/216154123-028946bf-ad2e-46fe-b0b0-e60ba8e2d678.png)

Where invoking the screenshot and taking a window screenshot of an empty desktop, the image made is of a transparent (black) desktop displaying icons - screenshot (window) is actually a taking a screenshot of a hidden window.  

In this case we should take a full screenshot rather than of the transparent window.

Tested with nemo that manages the desktop icons - with this PR - a window screenshot no longer just takes a screenshot of a transparent window showing the desktop icons.  Turning off desktop icons support in BDS and making a screenshot (window) screenshots the whole desktop as well.

Note - there should only ever be either zero or one window of window-hint DESKTOP.  I can't think of a scenario why there would be multiple windows of window-type DESKTOP.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
