### PR TITLE
Align panel settings layout with new Raven settings

### DIFF
--- a/src/panel/settings/settings_panel.vala
+++ b/src/panel/settings/settings_panel.vala
@@ -228,8 +228,6 @@ namespace Budgie {
 			};
 			Gtk.SizeGroup group = new Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL);
 
-
-
 			/* Position */
 			combobox_position = new Gtk.ComboBox();
 			position_id = combobox_position.changed.connect(this.set_position);

--- a/src/panel/settings/settings_panel.vala
+++ b/src/panel/settings/settings_panel.vala
@@ -69,6 +69,7 @@ namespace Budgie {
 			border_width = 0;
 			margin_top = 8;
 			margin_bottom = 8;
+			halign = Gtk.Align.FILL;
 
 			var swbox = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
 			this.pack_start(swbox, false, false, 0);
@@ -77,6 +78,8 @@ namespace Budgie {
 			switcher = new Gtk.StackSwitcher();
 			switcher.halign = Gtk.Align.CENTER;
 			stack = new Gtk.Stack();
+			stack.margin_top = 12;
+			stack.margin_bottom = 12;
 			stack.set_homogeneous(false);
 			switcher.set_stack(stack);
 			swbox.pack_start(switcher, true, true, 0);
@@ -218,10 +221,14 @@ namespace Budgie {
 		}
 
 		private Gtk.Widget? settings_page() {
-			SettingsGrid? ret = new SettingsGrid();
+			SettingsGrid? ret = new SettingsGrid() {
+				margin_top = 8,
+				margin_start = 20,
+				margin_end = 20,
+			};
 			Gtk.SizeGroup group = new Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL);
 
-			ret.border_width = 20;
+
 
 			/* Position */
 			combobox_position = new Gtk.ComboBox();
@@ -361,9 +368,7 @@ namespace Budgie {
 		}
 
 		private Gtk.Widget? applets_page() {
-			AppletsPage ret = new AppletsPage(this.manager, this.toplevel);
-			ret.border_width = 20;
-			return ret;
+			return new AppletsPage(this.manager, this.toplevel);
 		}
 
 		private void panel_notify(Object? o, ParamSpec ps) {

--- a/src/panel/settings/settings_panel_applets.vala
+++ b/src/panel/settings/settings_panel_applets.vala
@@ -16,8 +16,9 @@ namespace Budgie {
 	public class AppletSettingsFrame : Gtk.Box {
 		public AppletSettingsFrame() {
 			Object(orientation: Gtk.Orientation.VERTICAL, spacing: 0);
-			Gtk.Label lab = new Gtk.Label(_("Configure applet"));
-			lab.set_use_markup(true);
+
+			Gtk.Label lab = new Gtk.Label(null);
+			lab.set_markup("<big>%s</big>".printf(_("Widget Settings")));
 			lab.halign = Gtk.Align.START;
 			lab.margin_bottom = 6;
 			valign = Gtk.Align.START;
@@ -99,12 +100,12 @@ namespace Budgie {
 
 		public AppletsPage(Budgie.DesktopManager? manager, Budgie.Toplevel? toplevel) {
 			Object(orientation: Gtk.Orientation.HORIZONTAL, spacing: 0);
+
 			this.manager = manager;
 			this.toplevel = toplevel;
-			valign = Gtk.Align.FILL;
-			vexpand = false;
 
-			margin = 6;
+			halign = Gtk.Align.CENTER;
+			valign = Gtk.Align.FILL;
 
 			this.configure_list();
 			this.configure_actions();
@@ -190,10 +191,11 @@ namespace Budgie {
 			move_box.add(button_remove_applet);
 
 			frame_box.pack_start(move_box, false, false, 0);
+
 			var frame = new Gtk.Frame(null);
 			frame.vexpand = false;
 			frame.margin_end = 20;
-			frame.margin_top = 12;
+			frame.margin_top = 6;
 			frame.add(frame_box);
 
 			listbox_applets = new Gtk.ListBox();

--- a/src/panel/settings/settings_panel_applets.vala
+++ b/src/panel/settings/settings_panel_applets.vala
@@ -18,7 +18,7 @@ namespace Budgie {
 			Object(orientation: Gtk.Orientation.VERTICAL, spacing: 0);
 
 			Gtk.Label lab = new Gtk.Label(null);
-			lab.set_markup("<big>%s</big>".printf(_("Widget Settings")));
+			lab.set_markup("<big>%s</big>".printf(_("Applet Settings")));
 			lab.halign = Gtk.Align.START;
 			lab.margin_bottom = 6;
 			valign = Gtk.Align.START;


### PR DESCRIPTION
## Description

Tweaks the layout and spacing of the panel applets/settings view to match the layout of the new Raven widgets/settings view.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
