### PR TITLE
fix: Inability to capture fullscreen applications like games.

### DIFF
--- a/src/panel/settings/settings_wm.vala
+++ b/src/panel/settings/settings_wm.vala
@@ -81,7 +81,7 @@ namespace Budgie {
 			switch_unredirect = new Gtk.Switch();
 			grid.add_row(new SettingsRow(switch_unredirect,
 				_("Enable unredirection"),
-				_("Enable unredirection which will allow frames to bypass compositing for fullscreen application. This option is for advanced users and recommended to keep enabled. Use this if you are having graphical or performance issues with dedicated GPUs.")
+				_("Enable unredirection which will allow frames to bypass compositing for fullscreen applications. This option is for advanced users and recommended to keep enabled. Use this if you are having graphical or performance issues with dedicated GPUs.")
 			));
 
 			switch_all_windows_tabswitcher = new Gtk.Switch();

--- a/src/panel/settings/settings_wm.vala
+++ b/src/panel/settings/settings_wm.vala
@@ -80,8 +80,8 @@ namespace Budgie {
 			/* Unredirect.. */
 			switch_unredirect = new Gtk.Switch();
 			grid.add_row(new SettingsRow(switch_unredirect,
-				_("Disable unredirection of windows"),
-				_("This option is for advanced users. Use this if you are having graphical or performance issues with dedicated GPUs.")
+				_("Enable unredirection"),
+				_("Enable unredirection which will allow frames to bypass compositing for fullscreen application. This option is for advanced users and recommended to keep enabled. Use this if you are having graphical or performance issues with dedicated GPUs.")
 			));
 
 			switch_all_windows_tabswitcher = new Gtk.Switch();
@@ -114,7 +114,7 @@ namespace Budgie {
 			budgie_wm_settings.bind("pause-notifications-on-fullscreen", pause_notifications, "active", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("edge-tiling", switch_tiling,  "active", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("focus-mode", switch_focus, "active", SettingsBindFlags.DEFAULT);
-			budgie_wm_settings.bind("force-unredirect", switch_unredirect, "active", SettingsBindFlags.DEFAULT);
+			budgie_wm_settings.bind("enable-unredirect", switch_unredirect, "active", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("show-all-windows-tabswitcher", switch_all_windows_tabswitcher, "active", SettingsBindFlags.DEFAULT);
 		}
 	}

--- a/src/wm/com.solus-project.budgie.wm.gschema.xml
+++ b/src/wm/com.solus-project.budgie.wm.gschema.xml
@@ -89,7 +89,7 @@
 		<key type="b" name="enable-unredirect">
 			<default>true</default>
 			<summary>Enable unredirection of fullscreen applications</summary>
-			<description>Enable unredirection which will allow frames to bypass compositing for fullscreen application.</description>
+			<description>Enable unredirection which will allow frames to bypass compositing for fullscreen applications.</description>
 		</key>
 
 		<key type="b" name="show-all-windows-tabswitcher">

--- a/src/wm/com.solus-project.budgie.wm.gschema.xml
+++ b/src/wm/com.solus-project.budgie.wm.gschema.xml
@@ -88,7 +88,7 @@
 
 		<key type="b" name="enable-unredirect">
 			<default>true</default>
-			<summary>Enable unredirection</summary>
+			<summary>Enable unredirection of fullscreen applications</summary>
 			<description>Enable unredirection which will allow frames to bypass compositing for fullscreen application.</description>
 		</key>
 

--- a/src/wm/com.solus-project.budgie.wm.gschema.xml
+++ b/src/wm/com.solus-project.budgie.wm.gschema.xml
@@ -86,10 +86,10 @@
 			<description>This key overrides the key in org.gnome.desktop.wm.preferences when running Budgie.</description>
 		</key>
 
-		<key type="b" name="force-unredirect">
-			<default>false</default>
-			<summary>Forcibly disable screen unredirection</summary>
-			<description>Disables the screen unredirection which may improve performance with certain drivers.</description>
+		<key type="b" name="enable-unredirect">
+			<default>true</default>
+			<summary>Enable unredirection</summary>
+			<description>Enable unredirection which will allow frames to bypass compositing for fullscreen application.</description>
 		</key>
 
 		<key type="b" name="show-all-windows-tabswitcher">

--- a/src/wm/screenshot.vala
+++ b/src/wm/screenshot.vala
@@ -95,7 +95,7 @@ namespace Budgie {
 		}
 
 		public async void screenshot_area(int x, int y, int width, int height, bool include_cursor, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError {
-			var existing_unredirect = wm.force_unredirect;
+			var existing_unredirect = wm.enable_unredirect;
 			wm.set_redirection_mode(false); // Force the disabling of unredirect for clutter capture
 			yield wait_stage_repaint();
 
@@ -120,7 +120,7 @@ namespace Budgie {
 		}
 
 		public async void screenshot_window(bool include_frame, bool include_cursor, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError {
-			var existing_unredirect = wm.force_unredirect;
+			var existing_unredirect = wm.enable_unredirect;
 			wm.set_redirection_mode(false); // Force the disabling of unredirect for clutter capture
 			yield wait_stage_repaint();
 

--- a/src/wm/screenshot.vala
+++ b/src/wm/screenshot.vala
@@ -90,20 +90,13 @@ namespace Budgie {
 
 		public async void screenshot(bool include_cursor, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError {
 			int width, height;
-			yield wait_stage_repaint();
-
 			display.get_size(out width, out height);
-
-			var image = take_screenshot(0, 0, width, height, include_cursor);
-
-			if (flash) {
-				flash_area(0, 0, width, height);
-			}
-
-			success = yield save_image(image, filename, out filename_used);
+			yield screenshot_area(0, 0, width, height, include_cursor, flash, filename, out success, out filename_used);
 		}
 
 		public async void screenshot_area(int x, int y, int width, int height, bool include_cursor, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError {
+			var existing_unredirect = wm.force_unredirect;
+			wm.set_redirection_mode(false); // Force the disabling of unredirect for clutter capture
 			yield wait_stage_repaint();
 
 			// do some sizing checks
@@ -118,6 +111,8 @@ namespace Budgie {
 				flash_area(x, y, width, height);
 			}
 
+			wm.set_redirection_mode(existing_unredirect); // Restore old value
+
 			success = yield save_image(image, filename, out filename_used);
 			if (!success) {
 				throw new DBusError.FAILED("Failed to save image");
@@ -125,6 +120,8 @@ namespace Budgie {
 		}
 
 		public async void screenshot_window(bool include_frame, bool include_cursor, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError {
+			var existing_unredirect = wm.force_unredirect;
+			wm.set_redirection_mode(false); // Force the disabling of unredirect for clutter capture
 			yield wait_stage_repaint();
 
 			var window = display.get_focus_window();
@@ -167,6 +164,8 @@ namespace Budgie {
 			if (flash) {
 				flash_area(rect.x, rect.y, rect.width, rect.height);
 			}
+
+			wm.set_redirection_mode(existing_unredirect); // Restore old value
 
 			success = yield save_image(image, filename, out filename_used);
 			if (!success) {

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -14,7 +14,7 @@ namespace Budgie {
 	public const string MUTTER_MODAL_ATTACH = "attach-modal-dialogs";
 	public const string MUTTER_BUTTON_LAYOUT = "button-layout";
 	public const string EXPERIMENTAL_DIALOG = "experimental-enable-run-dialog-as-menu";
-	public const string WM_FORCE_UNREDIRECT = "force-unredirect";
+	public const string WM_ENABLE_UNREDIRECT = "enable-unredirect";
 	public const string WM_SCHEMA = "com.solus-project.budgie-wm";
 
 	public const bool CLUTTER_EVENT_PROPAGATE = false;
@@ -173,7 +173,7 @@ namespace Budgie {
 
 		Settings? iface_settings = null;
 
-		public bool force_unredirect = false;
+		public bool enable_unredirect = true;
 
 		HashTable<Meta.WindowActor?, AnimationState?> state_map;
 		Clutter.Actor? display_group;
@@ -582,7 +582,7 @@ namespace Budgie {
 			gnome_desktop_prefs = new Settings("org.gnome.desktop.wm.preferences");
 			this.settings.changed.connect(this.on_wm_schema_changed);
 			this.on_wm_schema_changed(EXPERIMENTAL_DIALOG);
-			this.on_wm_schema_changed(WM_FORCE_UNREDIRECT);
+			this.on_wm_schema_changed(WM_ENABLE_UNREDIRECT);
 
 			this.update_workspace_count(); // Update (create if necessary) our workspaces
 			gnome_desktop_prefs.changed["num-workspaces"].connect(this.update_workspace_count);
@@ -689,7 +689,7 @@ namespace Budgie {
 		private void on_wm_schema_changed(string key) {
 			if (key == EXPERIMENTAL_DIALOG) { // Key changed was the experimental enable
 				enabled_experimental_run_diag_as_menu = this.settings.get_boolean(key);
-			} else if (key == WM_FORCE_UNREDIRECT) {
+			} else if (key == WM_ENABLE_UNREDIRECT) {
 				set_redirection_mode(this.settings.get_boolean(key));
 			}
 		}
@@ -701,7 +701,7 @@ namespace Budgie {
 			} else {
 				Meta.Compositor.disable_unredirect_for_display(display);
 			}
-			this.force_unredirect = enable;
+			this.enable_unredirect = enable;
 		}
 
 		public override void show_window_menu(Meta.Window window, Meta.WindowMenuType type, int x, int y) {

--- a/src/wm/wm.vala
+++ b/src/wm/wm.vala
@@ -173,7 +173,7 @@ namespace Budgie {
 
 		Settings? iface_settings = null;
 
-		private bool force_unredirect = false;
+		public bool force_unredirect = false;
 
 		HashTable<Meta.WindowActor?, AnimationState?> state_map;
 		Clutter.Actor? display_group;
@@ -690,18 +690,18 @@ namespace Budgie {
 			if (key == EXPERIMENTAL_DIALOG) { // Key changed was the experimental enable
 				enabled_experimental_run_diag_as_menu = this.settings.get_boolean(key);
 			} else if (key == WM_FORCE_UNREDIRECT) {
-				bool enab = this.settings.get_boolean(key);
-
-				if (enab == this.force_unredirect) return;
-
-				var display = this.get_display();
-				if (enab) {
-					Meta.Compositor.enable_unredirect_for_display(display);
-				} else {
-					Meta.Compositor.disable_unredirect_for_display(display);
-				}
-				this.force_unredirect = enab;
+				set_redirection_mode(this.settings.get_boolean(key));
 			}
+		}
+
+		public void set_redirection_mode(bool enable) {
+			var display = this.get_display();
+			if (enable) {
+				Meta.Compositor.enable_unredirect_for_display(display);
+			} else {
+				Meta.Compositor.disable_unredirect_for_display(display);
+			}
+			this.force_unredirect = enable;
 		}
 
 		public override void show_window_menu(Meta.Window window, Meta.WindowMenuType type, int x, int y) {


### PR DESCRIPTION
Fixes #298. This also cleans up some duplication of logic between screen-type screenshot and area, where screen is just an area of the dimensions of the screen.

Similar to GNOME Shell, we will dynamically disable undirect, before potentially re-enabling it (if it was not explicitly disabled in our settings before the call to screenshot).

Tested in the following games, all running in exclusive fullscreen mode, across several instances of both "screen" and "window" capture to validate that these aren't just one-offs that worked:

- Halo: Reach in MCC
- OpenMW
- Sid Meier's Civilization VI

All the above games were running in exclusive fullscreen modes.