### PR TITLE
Ellipsize overflowing text in Media Controls widget header

### DIFF
--- a/src/raven/widgets/media-controls/mpris_gui.vala
+++ b/src/raven/widgets/media-controls/mpris_gui.vala
@@ -57,7 +57,12 @@ public class MprisClientWidget : Gtk.Box {
 		header_icon.margin_end = 10;
 		header.add(header_icon);
 
-		header_label = new Gtk.Label(client.player.identity);
+		header_label = new Gtk.Label(client.player.identity) {
+			xalign = 0.0f,
+			max_width_chars = 1,
+			ellipsize = Pango.EllipsizeMode.END,
+			hexpand = true,
+		};
 		header.add(header_label);
 
 		Gtk.Widget? row = null;

--- a/src/raven/widgets/media-controls/mpris_gui.vala
+++ b/src/raven/widgets/media-controls/mpris_gui.vala
@@ -63,6 +63,7 @@ public class MprisClientWidget : Gtk.Box {
 			ellipsize = Pango.EllipsizeMode.END,
 			hexpand = true,
 		};
+		header_label.set_tooltip_text(client.player.identity);
 		header.add(header_label);
 
 		Gtk.Widget? row = null;
@@ -298,17 +299,22 @@ public class MprisClientWidget : Gtk.Box {
 		switch (client.player.playback_status) {
 			case "Playing":
 				header_icon.set_from_icon_name("media-playback-start-symbolic", Gtk.IconSize.MENU);
-				header_label.set_text(_("%s - Playing").printf(client.player.identity));
+				var text = _("Playing - %s").printf(client.player.identity);
+				header_label.set_text(text);
+				header_label.set_tooltip_text(text);
 				((Gtk.Image) play_btn.get_image()).set_from_icon_name("media-playback-pause-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 				break;
 			case "Paused":
 				header_icon.set_from_icon_name("media-playback-pause-symbolic", Gtk.IconSize.MENU);
-				header_label.set_text(_("%s - Paused").printf(client.player.identity));
+				var text = _("Paused - %s").printf(client.player.identity);
+				header_label.set_text(text);
+				header_label.set_tooltip_text(text);
 				((Gtk.Image) play_btn.get_image()).set_from_icon_name("media-playback-start-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 				break;
 			default:
 				header_icon.set_from_icon_name("media-playback-stop-symbolic", Gtk.IconSize.MENU);
 				header_label.set_text(client.player.identity);
+				header_label.set_tooltip_text(client.player.identity);
 				((Gtk.Image) play_btn.get_image()).set_from_icon_name("media-playback-start-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 				break;
 		}


### PR DESCRIPTION
## Description

Resolves an issue wherein KDE Connect could cause Raven to expand in size due to providing a long player identity.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
