### PR TITLE
Implement setting to change sorting in Raven notification view

### DIFF
--- a/src/panel/settings/settings_raven_settings.vala
+++ b/src/panel/settings/settings_raven_settings.vala
@@ -12,6 +12,7 @@
  namespace Budgie {
 	public class RavenSettingsPage : Budgie.SettingsGrid {
 		private Gtk.ComboBox? raven_position;
+		private Gtk.ComboBox? notification_sort;
 		private Settings raven_settings;
 
 		public RavenSettingsPage() {
@@ -20,6 +21,7 @@
 			margin_end = 20;
 
 			raven_position = new Gtk.ComboBox();
+			notification_sort = new Gtk.ComboBox();
 
 			// Add options for Raven position
 			var render = new Gtk.CellRendererText();
@@ -46,8 +48,34 @@
 				_("Set which side of the screen Raven will open on. If set to Automatic, Raven will open where its parent panel is.")
 			));
 
+			// Add option for Notification sorting
+			var noti_renderer = new Gtk.CellRendererText();
+			var noti_model = new Gtk.ListStore(3, typeof(string), typeof(string), typeof(NotificationSort));
+			Gtk.TreeIter noti_iter;
+			const NotificationSort[] sortings = {
+				NEW_OLD,
+				OLD_NEW,
+			};
+
+			foreach (var sort in sortings) {
+				noti_model.append(out noti_iter);
+				noti_model.set(noti_iter, 0, sort.to_string(), 1, sort.get_display_name(), 2, sort, -1);
+			}
+
+			notification_sort.set_model(noti_model);
+			notification_sort.pack_start(noti_renderer, true);
+			notification_sort.add_attribute(noti_renderer, "text", 1);
+			notification_sort.set_id_column(0);
+
+			add_row(new SettingsRow(notification_sort,
+				_("Set notification sort order"),
+				_("Set whether notifications are sorted from oldest to newest, or newest to oldest.")
+			));
+
+			// Bind the settings to our comboboxes
 			raven_settings = new Settings("com.solus-project.budgie-raven");
 			raven_settings.bind("raven-position", raven_position, "active-id", SettingsBindFlags.DEFAULT);
+			raven_settings.bind("notification-sort", notification_sort, "active-id", SettingsBindFlags.DEFAULT);
 		}
 	}
 }

--- a/src/raven/com.solus-project.budgie.raven.gschema.xml
+++ b/src/raven/com.solus-project.budgie.raven.gschema.xml
@@ -6,6 +6,11 @@
     <value nick="BUDGIE_RAVEN_POSITION_RIGHT" value="3" />
   </enum>
 
+  <enum id="com.solus-project.budgie-raven.NotificationSort">
+    <value nick="BUDGIE_NOTIFICATION_SORT_NEW_OLD" value="1" />
+    <value nick="BUDGIE_NOTIFICATION_SORT_OLD_NEW" value="2" />
+  </enum>
+
   <schema path="/org/buddiesofbudgie/budgie-desktop/raven/widgets/" id="org.buddiesofbudgie.budgie-desktop.raven.widgets">
     <key type="as" name="uuids">
       <default>[]</default>
@@ -39,6 +44,12 @@
       <default>'BUDGIE_RAVEN_POSITION_AUTOMATIC'</default>
       <summary>Set Raven position</summary>
       <description>Set which side of the screen Raven will open on. If set to Automatic, Raven will open where its parent panel is.</description>
+    </key>
+
+    <key enum="com.solus-project.budgie-raven.NotificationSort" name="notification-sort">
+      <default>'BUDGIE_NOTIFICATION_SORT_NEW_OLD'</default>
+      <summary>Set notification sort order</summary>
+      <description>Set whether notifications are sorted from oldest to newest, or newest to oldest.</description>
     </key>
 
     <key type="b" name="allow-volume-overdrive">

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -40,6 +40,20 @@ namespace Budgie {
 		}
 	}
 
+	public enum NotificationSort {
+		NEW_OLD = 1,
+		OLD_NEW = 2;
+
+		public string get_display_name() {
+			switch (this) {
+				case OLD_NEW: return _("Oldest to newest");
+				case NEW_OLD:
+				default:
+					return _("Newest to oldest");
+			}
+		}
+	}
+
 	[DBus (name="org.budgie_desktop.Raven")]
 	public class RavenIface {
 		private Raven? parent = null;


### PR DESCRIPTION
## Description
Adds a setting to Budgie Desktop View to change the sorting order of notifications in Raven Notification View. The two options are from newest to oldest (default), and oldest to newest.

Closes #303 

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
