### PR TITLE
Fix SoundOutput and Calendar widget settings schemas

### DIFF
--- a/src/raven/widgets/calendar/org.buddiesofbudgie.budgie-desktop.raven.widget.Calendar.gschema.xml
+++ b/src/raven/widgets/calendar/org.buddiesofbudgie.budgie-desktop.raven.widget.Calendar.gschema.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="budgie">
-  <schema id="org.buddiesofbudgie.budgie-desktop.raven.widget.SoundOutput">
-    <key type="b" name="allow-volume-overdrive">
+  <schema id="org.buddiesofbudgie.budgie-desktop.raven.widget.Calendar">
+    <key type="b" name="show-week-numbers">
       <default>false</default>
-      <summary>Allow raising volume above 100%</summary>
-      <description>This setting overrides the one provided by org.gnome.desktop.sound.</description>
+      <summary>Display week numbers</summary>
+      <description>This setting enables the display of week numbers in the calendar.</description>
+    </key>
+    <key type="b" name="show-day-names">
+      <default>true</default>
+      <summary>Display day names</summary>
+      <description>This setting enables the display of day-of-the-week names in the calendar.</description>
     </key>
   </schema>
 </schemalist>

--- a/src/raven/widgets/sound-output/org.buddiesofbudgie.budgie-desktop.raven.widget.SoundOutput.gschema.xml
+++ b/src/raven/widgets/sound-output/org.buddiesofbudgie.budgie-desktop.raven.widget.SoundOutput.gschema.xml
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="budgie">
-  <schema id="org.buddiesofbudgie.budgie-desktop.raven.widget.Calendar">
-    <key type="b" name="show-week-numbers">
+  <schema id="org.buddiesofbudgie.budgie-desktop.raven.widget.SoundOutput">
+    <key type="b" name="allow-volume-overdrive">
       <default>false</default>
-      <summary>Display week numbers</summary>
-      <description>This setting enables the display of week numbers in the calendar.</description>
-    </key>
-    <key type="b" name="show-day-names">
-      <default>true</default>
-      <summary>Display day names</summary>
-      <description>This setting enables the display of day-of-the-week names in the calendar.</description>
+      <summary>Allow raising volume above 100%</summary>
+      <description>This setting overrides the one provided by org.gnome.desktop.sound.</description>
     </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
## Description

Somehow I mixed up the Calendar and SoundOutput settings schema contents. This PR just swaps them back around.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
