### PR TITLE
feat: ensure Budgie Menu application lists height allocation accounts for GTK scaling factor

### DIFF
--- a/src/panel/applets/budgie-menu/views/ListView.vala
+++ b/src/panel/applets/budgie-menu/views/ListView.vala
@@ -17,7 +17,9 @@
  */
 public class ApplicationListView : ApplicationView {
 	const int HEIGHT = 510;
+	const int WIDTH = 300;
 	private int SCALED_HEIGHT = HEIGHT;
+	private int SCALED_WIDTH = WIDTH;
 
 	private Gtk.Box categories;
 	private Gtk.ListBox applications;
@@ -46,10 +48,11 @@ public class ApplicationListView : ApplicationView {
 		);
 
 		SCALED_HEIGHT = HEIGHT / this.scale_factor;
+		SCALED_WIDTH = WIDTH / this.scale_factor;
 	}
 
 	construct {
-		this.set_size_request(300, SCALED_HEIGHT);
+		this.set_size_request(SCALED_WIDTH, SCALED_HEIGHT);
 		this.icon_size = settings.get_int("menu-icons-size");
 
 		this.categories = new Gtk.Box(Gtk.Orientation.VERTICAL, 0) {
@@ -129,7 +132,7 @@ public class ApplicationListView : ApplicationView {
 	*/
 	private void set_scaled_sizing(int scale) {
 		SCALED_HEIGHT = HEIGHT / scale;
-		this.set_size_request(300, SCALED_HEIGHT);
+		this.set_size_request(SCALED_WIDTH, SCALED_HEIGHT);
 
 		this.categories_scroll.min_content_height = SCALED_HEIGHT;
 		this.content_scroll.min_content_height = SCALED_HEIGHT;

--- a/src/panel/applets/budgie-menu/views/ListView.vala
+++ b/src/panel/applets/budgie-menu/views/ListView.vala
@@ -61,7 +61,7 @@ public class ApplicationListView : ApplicationView {
 		};
 
 		notify["scale-factor"].connect(() => {
-			this.set_scaled_sizing(this.scale_factor);
+			this.set_scaled_sizing();
 		});
 
 		this.categories_scroll = new Gtk.ScrolledWindow(null, null) {
@@ -125,14 +125,16 @@ public class ApplicationListView : ApplicationView {
 		// management of our listbox
 		this.applications.set_filter_func(do_filter_list);
 		this.applications.set_sort_func(do_sort_list);
+
+		this.set_scaled_sizing();
 	}
 
 	/**
 	* Sets various widgets to use sizing based on current scale and our default HEIGHT
 	*/
-	private void set_scaled_sizing(int scale) {
-		SCALED_HEIGHT = HEIGHT / scale;
-		SCALED_WIDTH = WIDTH / scale;
+	private void set_scaled_sizing() {
+		SCALED_HEIGHT = HEIGHT / this.scale_factor;
+		SCALED_WIDTH = WIDTH / this.scale_factor;
 		this.set_size_request(SCALED_WIDTH, SCALED_HEIGHT);
 
 		this.categories_scroll.min_content_height = SCALED_HEIGHT;

--- a/src/panel/applets/budgie-menu/views/ListView.vala
+++ b/src/panel/applets/budgie-menu/views/ListView.vala
@@ -132,6 +132,7 @@ public class ApplicationListView : ApplicationView {
 	*/
 	private void set_scaled_sizing(int scale) {
 		SCALED_HEIGHT = HEIGHT / scale;
+		SCALED_WIDTH = WIDTH / scale;
 		this.set_size_request(SCALED_WIDTH, SCALED_HEIGHT);
 
 		this.categories_scroll.min_content_height = SCALED_HEIGHT;

--- a/src/panel/applets/budgie-menu/views/ListView.vala
+++ b/src/panel/applets/budgie-menu/views/ListView.vala
@@ -17,6 +17,7 @@
  */
 public class ApplicationListView : ApplicationView {
 	const int HEIGHT = 510;
+	private int SCALED_HEIGHT = HEIGHT;
 
 	private Gtk.Box categories;
 	private Gtk.ListBox applications;
@@ -43,10 +44,12 @@ public class ApplicationListView : ApplicationView {
 			orientation: Gtk.Orientation.HORIZONTAL,
 			spacing: 0
 		);
+
+		SCALED_HEIGHT = HEIGHT / this.scale_factor;
 	}
 
 	construct {
-		this.set_size_request(300, HEIGHT);
+		this.set_size_request(300, SCALED_HEIGHT);
 		this.icon_size = settings.get_int("menu-icons-size");
 
 		this.categories = new Gtk.Box(Gtk.Orientation.VERTICAL, 0) {
@@ -54,12 +57,16 @@ public class ApplicationListView : ApplicationView {
 			margin_bottom = 3
 		};
 
+		notify["scale-factor"].connect(() => {
+			this.set_scaled_sizing(this.scale_factor);
+		});
+
 		this.categories_scroll = new Gtk.ScrolledWindow(null, null) {
 			overlay_scrolling = false,
 			shadow_type = Gtk.ShadowType.NONE, // Don't have an outline
 			hscrollbar_policy = Gtk.PolicyType.NEVER,
 			vscrollbar_policy = Gtk.PolicyType.AUTOMATIC,
-			min_content_height = HEIGHT,
+			min_content_height = SCALED_HEIGHT,
 			propagate_natural_height = true
 		};
 		this.categories_scroll.get_style_context().add_class("categories");
@@ -83,7 +90,7 @@ public class ApplicationListView : ApplicationView {
 			selection_mode = Gtk.SelectionMode.NONE,
 			valign = Gtk.Align.START,
 			// Make sure that the box at least covers the whole area. This helps more themes look better
-			height_request = HEIGHT
+			height_request = SCALED_HEIGHT
 		};
 		this.applications.row_activated.connect(this.on_row_activate);
 
@@ -91,7 +98,7 @@ public class ApplicationListView : ApplicationView {
 			overlay_scrolling = true,
 			hscrollbar_policy = Gtk.PolicyType.NEVER,
 			vscrollbar_policy = Gtk.PolicyType.AUTOMATIC,
-			min_content_height = HEIGHT
+			min_content_height = SCALED_HEIGHT
 		};
 		this.content_scroll.set_overlay_scrolling(true);
 		this.content_scroll.add(applications);
@@ -115,6 +122,18 @@ public class ApplicationListView : ApplicationView {
 		// management of our listbox
 		this.applications.set_filter_func(do_filter_list);
 		this.applications.set_sort_func(do_sort_list);
+	}
+
+	/**
+	* Sets various widgets to use sizing based on current scale and our default HEIGHT
+	*/
+	private void set_scaled_sizing(int scale) {
+		SCALED_HEIGHT = HEIGHT / scale;
+		this.set_size_request(300, SCALED_HEIGHT);
+
+		this.categories_scroll.min_content_height = SCALED_HEIGHT;
+		this.content_scroll.min_content_height = SCALED_HEIGHT;
+		this.applications.height_request = SCALED_HEIGHT;
 	}
 
 	/**


### PR DESCRIPTION
This ensures all parts of Budgie Menu are visible when used on resolutions such as 1080p with 200% scaling, rather than parts of it being cut off.