### PR TITLE
Use correct C header for meta_keybindings_set_custom_handler

### DIFF
--- a/vapi/Meta-12.metadata
+++ b/vapi/Meta-12.metadata
@@ -67,7 +67,7 @@ get_feedback_group_for_display parent="Meta.Compositor" cheader_filename="meta/c
 disable_unredirect_for_display parent="Meta.Compositor" cheader_filename="meta/compositor-mutter.h"
 enable_unredirect_for_display parent="Meta.Compositor" cheader_filename="meta/compositor-mutter.h"
 focus_stage_window parent="Meta.Compositor" cheader_filename="meta/compositor-mutter.h"
-keybindings_set_custom_handler parent="Meta.KeyBinding" name="set_custom_handler"
+keybindings_set_custom_handler parent="Meta.KeyBinding" name="set_custom_handler" cheader_filename="meta/keybindings.h"
 KeyHandlerFunc.event type="Clutter.KeyEvent?"
 Window.focus#signal skip=true
 Window.get_xwindow skip=false

--- a/vapi/libmutter-12.vapi
+++ b/vapi/libmutter-12.vapi
@@ -442,7 +442,8 @@ namespace Meta {
 		public unowned string get_name ();
 		public bool is_builtin ();
 		public bool is_reversed ();
-		[CCode (cname = "meta_keybindings_set_custom_handler")]
+		[CCode (cname = "meta_keybindings_set_custom_handler",
+			cheader_filename = "meta/keybindings.h" )]
 		public static bool set_custom_handler (string name, owned Meta.KeyHandlerFunc? handler);
 	}
 	[CCode (cheader_filename = "meta/main.h", type_id = "meta_laters_get_type ()")]


### PR DESCRIPTION
At least in Mutter 12, the function is declared in <meta/keybindings.h>, and not in <meta/main.h>.

This is necessary to avoid a build failure with future compilers which do not accept implicit function declarations by default.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC

There are further compiler failures after this, but they look more like a Vala compiler bug.