### PR TITLE
budgie-menu: Change the selection policy from NONE to SINGLE

### DIFF
--- a/src/panel/applets/budgie-menu/OverlayMenus.vala
+++ b/src/panel/applets/budgie-menu/OverlayMenus.vala
@@ -48,10 +48,11 @@ public class OverlayMenus : Revealer {
 		this.stack.set_homogeneous(false); // Make sure pages are same size
 		this.stack.set_transition_type(StackTransitionType.NONE); // Don't waste any time on transitions
 
-		this.folder_items = new ListBox();
+		this.folder_items = new ListBox() {
+			activate_on_single_click = false,
+			selection_mode = SelectionMode.SINGLE,
+		};
 		this.folder_items.get_style_context().add_class("left-overlay-menu");
-		this.folder_items.activate_on_single_click = false;
-		this.folder_items.selection_mode = SelectionMode.NONE;
 		this.folder_items.set_filter_func(this.filter_list_box_item);
 		this.folder_items.set_sort_func(this.sort_xdg_menu_items); // Ensure our menu items use our locale sorting
 

--- a/src/panel/applets/budgie-menu/views/ListView.vala
+++ b/src/panel/applets/budgie-menu/views/ListView.vala
@@ -90,7 +90,7 @@ public class ApplicationListView : ApplicationView {
 
 		// holds all the applications
 		this.applications = new Gtk.ListBox() {
-			selection_mode = Gtk.SelectionMode.NONE,
+			selection_mode = Gtk.SelectionMode.SINGLE,
 			valign = Gtk.Align.START,
 			// Make sure that the box at least covers the whole area. This helps more themes look better
 			height_request = SCALED_HEIGHT


### PR DESCRIPTION
## Description
When the ListBox selection mode is set to `NONE`, keyboard navigation within Budgie Menu works, but there is no visual indicator. Changing it to `SINGLE` allows themes to show a visual indication that an item is selected, and that the arrow keys on the keyboard changes the selection.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
