### PR TITLE
Add timeout to watcher init in tray applet

### DIFF
--- a/src/panel/applets/tray/TrayApplet.vala
+++ b/src/panel/applets/tray/TrayApplet.vala
@@ -113,8 +113,11 @@ public class TrayApplet : Budgie.Applet {
 			BusType.SESSION,
 			"org.freedesktop.StatusNotifierWatcher",
 			0,
-			(conn,name,owner)=>{on_watcher_init();},
-			(conn,name)=>{get_watcher_proxy();}
+			(conn, name, owner) => Timeout.add(500, () => {
+				on_watcher_init();
+				return false;
+			}),
+			(conn, name) => get_watcher_proxy()
 		);
 	}
 


### PR DESCRIPTION
## Description

#328 is caused by the tray applet attempting to fetch the watcher's DBus object before it's actually been registered to the bus, which is rare (as it has to happen IMMEDIATELY after the name is owned). This adds a 500ms timeout after the name is found, so the object has plenty of time to register itself.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
