### PR TITLE
Update tray plugin description

### DIFF
--- a/src/panel/applets/tray/TrayApplet.plugin.in
+++ b/src/panel/applets/tray/TrayApplet.plugin.in
@@ -2,7 +2,7 @@
 Module=trayapplet.so
 Builtin=true
 Name=System Tray
-_Description=System tray using the Status Notifier specification
+_Description=System tray implementing the Freedesktop Status Notifier specification.
 Authors=Budgie Desktop Developers
 Copyright=Copyright Budgie Desktop Developers
 Website=https://buddiesofbudgie.org/


### PR DESCRIPTION
## Description

Old: `System tray using the Status Notifier specification`
New: `System tray implementing the Freedesktop Status Notifier specification.`


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
