### PR TITLE
Make category buttons keyboard navigable

### DIFF
--- a/src/panel/applets/budgie-menu/BudgieMenuButtons.vala
+++ b/src/panel/applets/budgie-menu/BudgieMenuButtons.vala
@@ -13,34 +13,35 @@
  * Factory widget to represent a category
  */
 public class CategoryButton : Gtk.RadioButton {
-	public new Budgie.Category? category { public get ; protected set; }
+	public Budgie.Category? category { public get; construct; default = null; }
 
 	public CategoryButton(Budgie.Category? category) {
-		this.category = category;
+		Object(category: category);
+	}
 
-		string name = null;
-		if (category != null) {
-			name = category.name;
-		} else {
-			name = _("All");
-		}
+	construct {
+		var layout = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
 
-		Gtk.Label label = new Gtk.Label(name) {
+		var label = new Gtk.Label(null) {
 			halign = Gtk.Align.START,
 			valign = Gtk.Align.CENTER,
 			margin_start = 10,
 			margin_end = 15
 		};
 
-		var layout = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-		layout.pack_start(label, true, true, 0);
-		add(layout);
+		if (category == null) {
+			label.label = _("All");
+		} else {
+			label.label = category.name;
+		}
+
+		layout.pack_start(label);
 
 		get_style_context().add_class("flat");
 		get_style_context().add_class("category-button");
-		// Makes us look like a normal button :)
-		set_property("draw-indicator", false);
-		set_can_focus(false);
+		set_property("draw-indicator", false); // Makes us look like a normal button
+
+		add(layout);
 	}
 }
 

--- a/src/panel/applets/budgie-menu/views/ListView.vala
+++ b/src/panel/applets/budgie-menu/views/ListView.vala
@@ -81,9 +81,9 @@ public class ApplicationListView : ApplicationView {
 		this.all_categories = new CategoryButton(null);
 		this.all_categories.enter_notify_event.connect(this.on_mouse_enter);
 		this.all_categories.toggled.connect(()=> {
-			this.update_category(this.all_categories);
+			this.update_category(all_categories);
 		});
-		this.categories.pack_start(this.all_categories, false, false, 0);
+		this.categories.pack_start(all_categories, false);
 
 		var right_layout = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
 		this.pack_start(right_layout, true, true, 0);
@@ -161,9 +161,9 @@ public class ApplicationListView : ApplicationView {
 		this.control_center_buttons.clear();
 
 		// Destroy all category items
-		foreach (var child in this.categories.get_children()) {
+		this.categories.get_children().foreach((child) => {
 			child.destroy();
-		}
+		});
 
 		// Load all of the new content in the background
 		Idle.add(() => {
@@ -185,9 +185,10 @@ public class ApplicationListView : ApplicationView {
 		this.all_categories = new CategoryButton(null);
 		this.all_categories.enter_notify_event.connect(this.on_mouse_enter);
 		this.all_categories.toggled.connect(()=> {
-			this.update_category(this.all_categories);
+			this.update_category(all_categories);
 		});
-		this.categories.pack_start(this.all_categories, false, false, 0);
+		all_categories.show_all();
+		this.categories.pack_start(all_categories, false);
 
 		foreach (var category in app_tracker.get_categories()) {
 			// Skip empty categories
@@ -199,14 +200,12 @@ public class ApplicationListView : ApplicationView {
 			var btn = new CategoryButton(category);
 			btn.join_group(all_categories);
 			btn.enter_notify_event.connect(this.on_mouse_enter);
-
-			// Ensures we find the correct button
 			btn.toggled.connect(() => {
-				this.update_category(btn);
+				update_category(btn);
 			});
 
 			btn.show_all();
-			this.categories.pack_start(btn, false, false, 0); // Add the button
+			this.categories.pack_start(btn, false); // Add the button
 
 			// Create a button for each app in this category
 			foreach (var app in category.apps) {


### PR DESCRIPTION
## Description
Previously, you could not navigate between categories in the Budgie Menu using only the keyboard. This cleans up the category button code as well as making them focusable, thus enabling keyboard navigation.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
