### PR TITLE
Fix screenshot area-selection for libmutter-12

### DIFF
--- a/src/daemon/screenshot.vala
+++ b/src/daemon/screenshot.vala
@@ -637,6 +637,7 @@ namespace BudgieScr {
 			windowstate.statechanged(WindowState.SELECTINGAREA);
 			theme_settings = new GLib.Settings("org.gnome.desktop.interface");
 			this.set_type_hint(Gdk.WindowTypeHint.UTILITY);
+			this.set_decorated(false); // needed on libmutter-12
 			this.fullscreen();
 			this.set_keep_above(true);
 			get_theme_fillcolor();


### PR DESCRIPTION
## Description
This pull request fixes screenshot area selection on mutter 44.0-1ubuntu1/libmutter-12. We need to explicitly set `this.set_decorated(false)` in SelectLayer, to prevent the selection overlay to show decorators, resulting in a non-fullscreen overlay.
<Info on what this pull request adds>


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
