### PR TITLE
Register a daemon-side SN host

### DIFF
--- a/src/panel/applets/tray/TrayApplet.vala
+++ b/src/panel/applets/tray/TrayApplet.vala
@@ -113,7 +113,7 @@ public class TrayApplet : Budgie.Applet {
 			BusType.SESSION,
 			"org.freedesktop.StatusNotifierWatcher",
 			0,
-			(conn, name, owner) => Timeout.add(500, () => {
+			(conn, name, owner) => Timeout.add(100, () => {
 				on_watcher_init();
 				return false;
 			}),


### PR DESCRIPTION
## Description

This allows the panel to wait to attach to the host, while also ensuring that applications that start before the applet initializes can still register items. The wait before applet initialization has also been reduced from 500ms to 100ms.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
