### PR TITLE
Add clangd cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 justfile
 /.fleet/
 /.idea/
+/.cache/


### PR DESCRIPTION
## Description

clangd can be used with Visual Studio Code, and we definitely shouldn't be committing its cache.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
