### PR TITLE
fix: check of zenity on OSes with older Meson

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@v1
       - run: sudo apt update
       - run: sudo apt remove libunwind-14-dev
-      - run: sudo apt install meson ninja-build gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libcanberra-dev libcanberra-gtk3-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac libgstreamer1.0-dev libgee-0.8-dev
+      - run: sudo apt install meson ninja-build zenity gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libcanberra-dev libcanberra-gtk3-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac libgstreamer1.0-dev libgee-0.8-dev
       - run: meson build -Dwith-gnome-screensaver=true
       - run: meson compile -C build

--- a/meson.build
+++ b/meson.build
@@ -61,9 +61,6 @@ dep_accountsservice = dependency('accountsservice', version: '>= 0.6.55')
 dep_canberra = dependency('libcanberra')
 dep_canberra_gtk3 = dependency('libcanberra-gtk3')
 
-zenity = find_program('zenity')
-assert(zenity.found(), 'Zenity is a required program at build and run-time for dialog support in budgie-wm. Please include it in both build and run deps.')
-
 # Create config.h
 cdata = configuration_data()
 

--- a/src/wm/meson.build
+++ b/src/wm/meson.build
@@ -18,8 +18,16 @@ budgie_wm_sources = [
 
 budgie_wm_status_vala_args = []
 
-if zenity.version().version_compare('>=3.90')
+# Yes I know version() exists and that would be simpler, I need to support Ubuntus that don't have modern meson so this is the hack
+zenity_new = find_program('zenity', version: '>=3.90', required: false)
+zenity_old = find_program('zenity', version: '<3.90', required: false)
+assert(zenity_new.found() or zenity_old.found(), 'Zenity is a required program at build and run-time for dialog support in budgie-wm. Please include it in both build and run deps.')
+
+if zenity_new.found()
+    message('Found new zenity, using new zenity flags')
     budgie_wm_status_vala_args += ['-D', 'HAVE_NEW_ZENITY']
+else
+    message('Found old zenity, using old zenity flags')
 endif
 
 dep_graphene = dependency('graphene-gobject-1.0', version: '>= 1.10')

--- a/src/wm/meson.build
+++ b/src/wm/meson.build
@@ -19,11 +19,12 @@ budgie_wm_sources = [
 budgie_wm_status_vala_args = []
 
 # Yes I know version() exists and that would be simpler, I need to support Ubuntus that don't have modern meson so this is the hack
-zenity_new = find_program('zenity', version: '>=3.90', required: false)
-zenity_old = find_program('zenity', version: '<3.90', required: false)
-assert(zenity_new.found() or zenity_old.found(), 'Zenity is a required program at build and run-time for dialog support in budgie-wm. Please include it in both build and run deps.')
+zenity = find_program('zenity', required: false)
+assert(zenity.found(), 'Zenity is a required program at build and run-time for dialog support in budgie-wm. Please include it in both build and run deps.')
 
-if zenity_new.found()
+zenity_version = run_command('zenity', ['--version'], capture: true)
+
+if zenity_version.stdout().version_compare('>=3.90') == true
     message('Found new zenity, using new zenity flags')
     budgie_wm_status_vala_args += ['-D', 'HAVE_NEW_ZENITY']
 else


### PR DESCRIPTION
This PR fixes zenity detection on OSes which do not have a new enough meson to have its `version()` check.
