### PR TITLE
Built-in theme recolor

### DIFF
--- a/src/theme/3.20/_main.scss
+++ b/src/theme/3.20/_main.scss
@@ -156,13 +156,3 @@
 }
 @include raven-trigger(button);
 @include raven-mpris(button);
-
-@each $pos, $b_pos in $pos_list {
-    // Raven borders
-    .#{$pos} .raven-frame {
-        border {
-            border: none;
-            border-#{$b_pos}: $border_width solid $raven_border;
-        }
-    }
-}

--- a/src/theme/common/_colors.scss
+++ b/src/theme/common/_colors.scss
@@ -1,7 +1,7 @@
 $fg_color: if($variant == 'default', white, black);
 
-$selected_bg_color: if($variant =='default', #4791CA, black);
-$selected_fg_color: white;
+$selected_bg_color: if($variant =='default', rgb(107, 202, 129), black);
+$selected_fg_color: black;
 
 $warning_color: #F27835;
 $error_color: #FC4138;
@@ -9,18 +9,18 @@ $alert_color: #4fa2e1;
 $destructive_color: #F04A50;
 $suggested_color: #4DADD4;
 
-$panel_bg: if($variant == 'default', #252a35, white);
+$panel_bg: if($variant == 'default', #161616, white);
 $panel_border: if($variant == 'default', #0f1116, black);
 $panel_shadow: transparentize(black, 0.7);
 
-$raven_bg: if($variant == 'default', #353945, $panel_bg);
+$raven_bg: if($variant == 'default', #1f1f1f, $panel_bg);
 $raven_border: if($variant == 'default', transparentize($panel_border, 0.05), $panel_border);
 
-$raven_expander_bg: if($variant == 'default', darken($raven_bg, 6.5%), $raven_bg);
+$raven_expander_bg: if($variant == 'default', #333333, $raven_bg);
 $raven_expander_fg: $fg_color;
 $raven_expander_border: if($variant == 'default', $raven_expander_bg, $raven_border);
 
-$raven_background_bg: if($variant == 'default', darken($raven_bg, 4%), $raven_bg);
+$raven_background_bg: if($variant == 'default', #333333, $raven_bg);
 $raven_background_border: if($variant == 'default', $raven_background_bg, $raven_border);
 
 $mpris_overlay_bg: transparentize(white, 0.9);

--- a/src/theme/common/_colors.scss
+++ b/src/theme/common/_colors.scss
@@ -5,22 +5,22 @@ $selected_fg_color: black;
 
 $warning_color: #F27835;
 $error_color: #FC4138;
-$alert_color: #4fa2e1;
+$alert_color: rgb(107, 202, 129);
 $destructive_color: #F04A50;
-$suggested_color: #4DADD4;
+$suggested_color: rgb(107, 202, 129);
 
 $panel_bg: if($variant == 'default', #161616, white);
 $panel_border: if($variant == 'default', #0f1116, black);
 $panel_shadow: transparentize(black, 0.7);
 
-$raven_bg: if($variant == 'default', #1f1f1f, $panel_bg);
+$raven_bg: if($variant == 'default', #161616, $panel_bg);
 $raven_border: if($variant == 'default', transparentize($panel_border, 0.05), $panel_border);
 
-$raven_expander_bg: if($variant == 'default', #333333, $raven_bg);
+$raven_expander_bg: if($variant == 'default', #262626, $raven_bg);
 $raven_expander_fg: $fg_color;
 $raven_expander_border: if($variant == 'default', $raven_expander_bg, $raven_border);
 
-$raven_background_bg: if($variant == 'default', #333333, $raven_bg);
+$raven_background_bg: if($variant == 'default', #262626, $raven_bg);
 $raven_background_border: if($variant == 'default', $raven_background_bg, $raven_border);
 
 $mpris_overlay_bg: transparentize(white, 0.9);

--- a/src/theme/common/_menu.scss
+++ b/src/theme/common/_menu.scss
@@ -31,9 +31,9 @@
 
         padding: 6px 0;
         font-size: 14px;
-
-        border-bottom: 2px solid transparentize($selected_bg_color, 0.5);
-        border-radius: 0;
+        border-radius: 6px;
+        background-color: transparentize(white, 0.9);
+        margin-bottom: 8px;
 
         #{$image} {
             color: currentColor;
@@ -60,11 +60,13 @@
             transition: 170ms ease-out;
             margin: 2px 0;
             padding: 4px 8px;
-            border-radius: 3px;
+            border-radius: 6px;
 
             &:hover { background-color: transparentize(white, 0.9); }
             &:active {
-                color: $selected_fg_color;
+                label {
+                    color: $selected_fg_color;
+                }
                 background-color: $selected_bg_color;
             }
 
@@ -83,7 +85,6 @@
     }
 
     .budgie-menu-footer {
-        border-top: 1px solid transparentize(white, 0.9);
         padding-top: 6px;
 
         .image-button {
@@ -106,7 +107,7 @@
             transition-property: background-color, color;
             transition: 170ms ease-out;
             padding: 4px 8px 4px 6px;
-            border-radius: 3px;
+            border-radius: 6px;
 
             &:hover { background-color: transparentize(white, 0.9); }
             &:active { background-color: transparentize(white, 0.8); }
@@ -129,7 +130,7 @@
             padding: 4px 8px 4px 2px;
             margin: 2px 0;
             background-color: transparent;
-            border-radius: 3px;
+            border-radius: 6px;
 
             &:hover { background-color: transparentize(white, 0.9); }
             &:active { background-color: transparentize(white, 0.8); }
@@ -141,7 +142,6 @@
 
         margin: 0;
         padding: 0 5px 0 0;
-        border-right: 1px solid transparentize(white, 0.9);
     }
 
     .category-button {
@@ -149,13 +149,15 @@
 
         margin: 2px 0;
         padding: 6px 0;
-        border-radius: 3px;
+        border-radius: 6px;
         transition-property: background-color, color;
         transition: 170ms ease-out;
 
         &:hover { background-color: transparentize(white, 0.9); }
         &:active, &:checked {
-            color: $selected_fg_color;
+            label {
+                color: $selected_fg_color;
+            }
             background-color: $selected_bg_color;
         }
         &:checked:#{$insensitive} {

--- a/src/theme/common/_menu.scss
+++ b/src/theme/common/_menu.scss
@@ -132,8 +132,17 @@
             background-color: transparent;
             border-radius: 6px;
 
+            > image {
+                color: white;
+            }
+
             &:hover { background-color: transparentize(white, 0.9); }
-            &:active { background-color: transparentize(white, 0.8); }
+            &:active {
+                color: $selected_fg_color;
+                > image {
+                    color: $selected_fg_color;
+                }
+            }
         }
     }
 
@@ -162,8 +171,6 @@
         }
         &:checked:#{$insensitive} {
             opacity: 0.5;
-
-            #{$label} { color: inherit; }
         }
     }
 


### PR DESCRIPTION
## Description

Replaces the color scheme currently in the Budgie built-in theme with the color scheme from the mockups of the complete theme rewrite. Neutral dark grey for background colors, Budgie green for selected buttons. Additionally, the Budgie Menu theming has been updated to fit that mockup.

![main](https://user-images.githubusercontent.com/12981608/236713638-378f2ada-c8aa-420a-bc2e-8aef182c3c02.png)

![New version](https://user-images.githubusercontent.com/12981608/236713543-85d30b38-6210-44b5-a5a1-6e89734e441b.png)

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
