### PR TITLE
Workaround Private Internet Access not showing up in Icon Task List

### DIFF
--- a/src/abomination/abomination.vala
+++ b/src/abomination/abomination.vala
@@ -95,7 +95,7 @@ namespace Budgie.Abomination {
 			Wnck.WindowType win_type = window.get_window_type(); // Get the window type
 
 			return (win_type == Wnck.WindowType.DESKTOP) || // Desktop-mode (like Budgie Desktop View)
-				   (win_type == Wnck.WindowType.DIALOG) || // Dialogs
+				   (win_type == Wnck.WindowType.DIALOG && window.get_transient() != null) || // Dialogs
 				   (win_type == Wnck.WindowType.DOCK) || // Like Budgie Panel
 				   (win_type == Wnck.WindowType.SPLASHSCREEN) || // Splash screens
 				   (win_type == Wnck.WindowType.UTILITY); // Utility like a control on an emulator


### PR DESCRIPTION
## Description

This adds a caveat to `is_disallowed_window_type`, where windows of type `WindowType.DIALOG` are only not shown if they're transient to a parent window. In combination with `is_skip_tasklist` and `is_skip_pager`, this should block most *actual* dialogs.

This resolves #266.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
