### PR TITLE
Remove style class changes in power dialog

### DIFF
--- a/src/dialogs/power/window.vala
+++ b/src/dialogs/power/window.vala
@@ -45,9 +45,8 @@ namespace Budgie {
 		Budgie.ThemeManager? theme_manager = null;
 
 		construct {
-			maximize(); // Try to prevent the dialog window from losing focus
 			set_keep_above(true);
-			set_position(WindowPosition.CENTER);
+			set_position(WindowPosition.CENTER_ALWAYS);
 
 			var visual = screen.get_rgba_visual();
 			if (visual != null) {
@@ -55,7 +54,6 @@ namespace Budgie {
 			}
 
 			get_style_context().add_class("budgie-power-dialog");
-			get_style_context().remove_class("background");
 
 			theme_manager = new Budgie.ThemeManager();
 
@@ -71,9 +69,6 @@ namespace Budgie {
 				halign = Align.CENTER,
 				valign = Align.CENTER
 			};
-
-			box.get_style_context().add_class("background");
-			box.get_style_context().add_class("drop-shadow");
 
 			var button_grid = new Grid() {
 				column_homogeneous = true,


### PR DESCRIPTION
## Description

This fixes the case where themes that don't style the dialog end up having a transparent background, making it very hard to see and use the dialog.

One thing to be aware of is that the previous way was done to combat focus issues when presenting the dialog under certain conditions. So far, though, I have been unable to get the focus to mess up with the new changes; the dialog is always focused correctly.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
