### PR TITLE
Port the fuzzy scoring function to C

### DIFF
--- a/src/appindexer/RelevancyService.vala
+++ b/src/appindexer/RelevancyService.vala
@@ -108,7 +108,7 @@ namespace Budgie {
 			string _term = term.casefold();
 
 			// Get a initial score based on the fuzzy match of the name
-			var score = get_fuzzy_score(name, _term, 1);
+			var score = Fuzzer.get_fuzzy_score(name, _term, 1);
 
 			// If the term is considered to be an exact match, bail early
 			if (score == 0) {
@@ -157,69 +157,6 @@ namespace Budgie {
 
 			// Set the score
 			scores.set(app.desktop_id, int.max(score, 0));
-		}
-
-		/**
-		 * Fuzzily matches two strings using the Fuzzy Bitap Algorithm.
-		 *
-		 * The algorithm tells whether a given text contains a substring
-		 * which is "approximately equal" to a given pattern, where approximate
-		 * equality is defined in terms of Levenshtein distance.
-		 *
-		 * The algorithm begins by precomputing a set of bitmasks containing one
-		 * bit for each element of the pattern. Then it is able to do most of the
-		 * work with bitwise operations, which are extremely fast.
-		 *
-		 * Adapted from here: https://www.programmingalgorithms.com/algorithm/fuzzy-bitap-algorithm/
-		 *
-		 * @param text The text to compare to.
-		 * @param pattern The pattern to match against.
-		 * @param max_distance The maximum distance between the strings to still be considered equal.
-		 */
-		private int get_fuzzy_score(string text, string pattern, int max_distance) {
-			var result = -1;
-			var pattern_length = pattern.length;
-			int[] bit_array;
-			int[] pattern_mask = new int[128];
-			int i, d;
-
-			if (pattern == "") return 0; // Pattern is empty
-			if (pattern_length > 31) return -1; // Error: pattern too long
-
-			/* Initialize the bit array */
-			bit_array = new int[(max_distance + 1) * sizeof(int)];
-
-			/* Initialize the pattern masks */
-			for (i = 0; i <= max_distance; ++i) bit_array[i] = ~1;
-
-			for (i = 0; i <= 127; ++i) pattern_mask[i] = ~0;
-
-			for (i = 0; i < pattern_length; ++i) pattern_mask[pattern[i]] &= ~(1 << i);
-
-			/* Calculating the score */
-
-			for (i = 0; i < text.length; ++i) {
-				/* Update the bit arrays */
-				var old_Rd1 = bit_array[0];
-
-				bit_array[0] |= pattern_mask[text[i]];
-				bit_array[0] <<= 1;
-
-				for (d = 1; d <= max_distance; ++d) {
-					var tmp = bit_array[d];
-
-					/* Only look for substitutions */
-					bit_array[d] = (old_Rd1 & (bit_array[d] | pattern_mask[text[i]])) << 1;
-					old_Rd1 = tmp;
-				}
-
-				if (0 == (bit_array[max_distance] & (1 << pattern_length))) {
-					result = (i - pattern_length) + 1;
-					break;
-				}
-			}
-
-			return result;
 		}
 
 		/* Helper ported from Brisk */

--- a/src/appindexer/fuzzer/fuzzer-1.0.vapi
+++ b/src/appindexer/fuzzer/fuzzer-1.0.vapi
@@ -1,0 +1,4 @@
+namespace Fuzzer {
+	[CCode (cheader_filename="fuzzer.h")]
+	public static int get_fuzzy_score(string text, string pattern, int max_distance);
+}

--- a/src/appindexer/fuzzer/fuzzer.c
+++ b/src/appindexer/fuzzer/fuzzer.c
@@ -1,0 +1,77 @@
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fuzzer.h"
+
+/**
+ * fuzzer_get_fuzzy_score:
+ * @text: the text to compare to
+ * @pattern: the text being used to search
+ * @max_distance: the maximum distance between the strings to still be considered equal
+ *
+ * Fuzzily matches two strings using the Fuzzy Bitap Algorithm.
+ *
+ * The algorithm tells whether a given text contains a substring
+ * which is "approximately equal" to a given pattern, where approximate
+ * equality is defined in terms of Levenshtein distance.
+ *
+ * The algorithm begins by precomputing a set of bitmasks containing one
+ * bit for each element of the pattern. Then it is able to do most of the
+ * work with bitwise operations, which are extremely fast.
+ *
+ * Adapted from here: https://www.programmingalgorithms.com/algorithm/fuzzy-bitap-algorithm/
+ *
+ * Return value: a score based on the closeness of the texts
+ */
+gint fuzzer_get_fuzzy_score(const gchar *text, const gchar *pattern, gint max_distance) {
+	gint result = -1;
+	gint pattern_length;
+	guint64 *bit_array = NULL;
+	guint64 pattern_mask[CHAR_MAX + 1];
+	gint i, d;
+
+	g_return_val_if_fail(text != NULL, -1);
+	g_return_val_if_fail(pattern != NULL, -1);
+
+	pattern_length = strlen(pattern);
+
+	if (g_strcmp0(pattern, "") == 0) return 0; // Pattern is empty
+	if (pattern_length > 31) return -1; // Error: pattern too long
+
+	/* Initialize the bit array */
+	bit_array = (guint64 *) malloc((max_distance + 1) * sizeof(*bit_array));
+	for (i = 0; i <= max_distance; ++i) bit_array[i] = ~1;
+
+	/* Initialize the pattern masks */
+	for (i = 0; i <= 127; ++i) pattern_mask[i] = ~0;
+
+	for (i = 0; i < pattern_length; ++i) pattern_mask[pattern[i]] &= ~(1UL << i);
+
+	/* Calculating the score */
+
+	for (i = 0; text[i] != '\0'; ++i) {
+		/* Update the bit arrays */
+		guint64 old_Rd1 = bit_array[0];
+
+		bit_array[0] |= pattern_mask[text[i]];
+		bit_array[0] <<= 1;
+
+		for (d = 1; d <= max_distance; ++d) {
+			guint64 tmp = bit_array[d];
+
+			/* Only look for substitutions */
+			bit_array[d] = (old_Rd1 & (bit_array[d] | pattern_mask[text[i]])) << 1;
+			old_Rd1 = tmp;
+		}
+
+		if (0 == (bit_array[max_distance] & (1UL << pattern_length))) {
+			result = (i - pattern_length) + 1;
+			break;
+		}
+	}
+
+	g_free(bit_array);
+
+	return result;
+}

--- a/src/appindexer/fuzzer/fuzzer.h
+++ b/src/appindexer/fuzzer/fuzzer.h
@@ -1,0 +1,12 @@
+#ifndef __FUZZER_H__
+#define __FUZZER_H__
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+gint fuzzer_get_fuzzy_score(const gchar *text, const gchar *pattern, gint max_distance);
+
+G_END_DECLS
+
+#endif

--- a/src/appindexer/fuzzer/meson.build
+++ b/src/appindexer/fuzzer/meson.build
@@ -1,0 +1,21 @@
+libfuzzer_deps = [
+    dep_glib,
+]
+
+libfuzzer_sources = [
+    'fuzzer.c',
+]
+
+libfuzzer = static_library(
+    'fuzzer',
+    libfuzzer_sources,
+    dependencies: libfuzzer_deps,
+    include_directories: [
+        include_directories('.'),
+    ]
+)
+
+link_libfuzzer = declare_dependency(
+    link_with: libfuzzer,
+    include_directories: include_directories('.'),
+)

--- a/src/appindexer/meson.build
+++ b/src/appindexer/meson.build
@@ -1,3 +1,5 @@
+subdir('fuzzer')
+
 appindexer_sources = [
     'AppIndex.vala',
     'Application.vala',
@@ -13,11 +15,13 @@ libappindexer = shared_library(
         dep_gee,
         dep_giounix,
         dep_gtk3,
+        link_libfuzzer,
     ],
     vala_args: [
         '--pkg', 'gtk+-3.0',
         '--pkg', 'gio-unix-2.0',
         '--vapidir', join_paths(meson.source_root(), 'vapi'),
+        join_paths(meson.source_root(), 'src', 'appindexer', 'fuzzer', 'fuzzer-1.0.vapi'),
     ],
     version: '0.0.0',
     install: true,


### PR DESCRIPTION
## Description
When transpiling to C, Vala really mangles this function, causing it to crash randomly on non-Latin text. Porting it to C and checking it against the reference implementation found online fixes the crashing issue while (as far as I can tell with Spanish) still producing the desired search results.

Another consideration was converting the search text and compare text to ASCII. This method also seems to fix the issue, though it feels more dirty. I decided to go forward with the C port because I simply can't trust Vala to do the right thing when it comes to this function.

Fixes #383

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
