### PR TITLE
Use ngettext for plural strings

### DIFF
--- a/src/daemon/notifications/dbus.vala
+++ b/src/daemon/notifications/dbus.vala
@@ -554,11 +554,7 @@
 			var summary = _("Unread Notifications");
 
 			string? body = null;
-			if (paused_notifications == 1) {
-				body = _("You received 1 notification while an application was fullscreened.");
-			} else {
-				body = _("You received %d notifications while an application was fullscreened.".printf(this.paused_notifications));
-			}
+			body = ngettext("You received %d notification while an application was fullscreened.", "You received %d notifications while an application was fullscreened.", this.paused_notifications).printf(this.paused_notifications);
 
 			var icon = "dialog-information";
 

--- a/src/daemon/notifications/dbus.vala
+++ b/src/daemon/notifications/dbus.vala
@@ -553,8 +553,11 @@
 			// translators: This is the title of a notification that is shown after notifications have been blocked because an application was in fullscreen mode
 			var summary = _("Unread Notifications");
 
-			string? body = null;
-			body = ngettext("You received %d notification while an application was fullscreened.", "You received %d notifications while an application was fullscreened.", this.paused_notifications).printf(this.paused_notifications);
+			string body = ngettext(
+				"You received %d notification while an application was fullscreened.",
+				"You received %d notifications while an application was fullscreened.",
+				this.paused_notifications
+			).printf(this.paused_notifications);
 
 			var icon = "dialog-information";
 

--- a/src/daemon/settings.vala
+++ b/src/daemon/settings.vala
@@ -341,9 +341,7 @@ namespace Budgie {
 				string icon = (enabled) ? caffeine_full_cup : caffeine_empty_cup;
 
 				if (enabled && (time > 0)) {
-					var duration = ngettext("Will turn off in a minute", "Will turn off in %d minutes", time).printf(time);
-
-					body = duration;
+					body = ngettext("Will turn off in a minute", "Will turn off in %d minutes", time).printf(time);
 				}
 
 				if (this.caffeine_notification == null) { // Caffeine Notification not yet created

--- a/src/daemon/settings.vala
+++ b/src/daemon/settings.vala
@@ -341,11 +341,7 @@ namespace Budgie {
 				string icon = (enabled) ? caffeine_full_cup : caffeine_empty_cup;
 
 				if (enabled && (time > 0)) {
-					var duration = _("Will turn off in a minute");
-
-					if (time > 1) { // use plural
-						duration = _("Will turn off in %d minutes").printf(time);
-					}
+					var duration = ngettext("Will turn off in a minute", "Will turn off in %d minutes", time).printf(time);
 
 					body = duration;
 				}

--- a/src/panel/applets/notifications/NotificationsApplet.vala
+++ b/src/panel/applets/notifications/NotificationsApplet.vala
@@ -117,10 +117,8 @@ public class NotificationsApplet : Budgie.Applet {
 			return;
 		}
 
-		if (count > 1) {
-			this.icon.set_tooltip_text(_("%u unread notifications").printf(count));
-		} else if (count == 1) {
-			this.icon.set_tooltip_text(_("1 unread notification"));
+		if (count > 0) {
+			this.icon.set_tooltip_text(ngettext("%u unread notification", "%u unread notifications", count).printf(count));
 		} else {
 			this.icon.set_tooltip_text(_("No unread notifications"));
 		}


### PR DESCRIPTION
Use ngettext plural support to allow proper translations.
