### PR TITLE
Prevent notifs and scrshot from locking up when sink is locked

### DIFF
--- a/src/daemon/notifications/dbus.vala
+++ b/src/daemon/notifications/dbus.vala
@@ -471,28 +471,13 @@
 				sound_name = notification.hints.get("sound-name").get_string();
 			}
 
-			play_sound(notification, sound_name);
-		}
-
-		/**
-		 * Play a sound for a notification.
-		 */
-		private void play_sound(Notification notification, string? sound_name = "dialog-information") {
 			// Try to map the notification's category to a sound name to use
 			if (sound_name == "dialog-information" && notification.category != null) {
 				sound_name = get_sound_for_category(notification.category);
 			}
 
-			// Play the sound
-			if (sound_name != null) {
-				Canberra.Proplist props;
-				Canberra.Proplist.create(out props);
-
-				props.sets(Canberra.PROP_CANBERRA_CACHE_CONTROL, "volatile");
-				props.sets(Canberra.PROP_EVENT_ID, sound_name);
-
-				CanberraGtk.context_get().play_full(0, props);
-			}
+			var player = new SoundPlayer(notification, sound_name);
+			new Thread<void>(null, player.play);
 		}
 
 		/**
@@ -615,6 +600,29 @@
 				});
 			} catch (Error e) {
 				critical("Error starting notification thread: %s", e.message);
+			}
+		}
+	}
+
+	class SoundPlayer {
+		private Notification notification;
+		private string? sound_name;
+
+		public SoundPlayer(Notification notification, string? sound_name = "dialog-information") {
+			this.notification = notification;
+			this.sound_name = sound_name;
+		}
+
+		public void play() {
+			// Play the sound
+			if (sound_name != null) {
+				Canberra.Proplist props;
+				Canberra.Proplist.create(out props);
+
+				props.sets(Canberra.PROP_CANBERRA_CACHE_CONTROL, "volatile");
+				props.sets(Canberra.PROP_EVENT_ID, sound_name);
+
+				CanberraGtk.context_get().play_full(0, props);
 			}
 		}
 	}

--- a/src/daemon/screenshot.vala
+++ b/src/daemon/screenshot.vala
@@ -297,7 +297,8 @@ namespace BudgieScr {
 				// fake thread to make sure flash and shutter are in sync
 				pipeline.set_state(State.PLAYING);
 				Gst.Bus bus = pipeline.get_bus();
-				bus.timed_pop_filtered(Gst.CLOCK_TIME_NONE, Gst.MessageType.ERROR | Gst.MessageType.EOS);
+				// time out after 2 seconds, in case the output is locked
+				bus.timed_pop_filtered(2000000000, Gst.MessageType.ERROR | Gst.MessageType.EOS);
 				pipeline.set_state(Gst.State.NULL);
 
 				return false;


### PR DESCRIPTION
## Description

The two cases are handled differently, as screenshots use gstreamer and notifs use canberra.

The screenshot sound now has a timeout of 2 seconds, after which it will cancel the attempt to play the sound and just move forward with the screenshot. This may cut off longer screenshot sounds, but it doesn't cut off the default.

The notif sounds are now launched as threads, so they don't block the main thread when queued up. This means that all buffered notif sounds will play upon the default sink being unlocked, but this is how all other sound players work, so it's not a big deal.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
