### PR TITLE
trash-applet: Try to use GFile wherever possible

### DIFF
--- a/src/panel/applets/trash/trash_applet.c
+++ b/src/panel/applets/trash/trash_applet.c
@@ -215,18 +215,18 @@ static void drag_data_received(
 	g_return_if_fail(info == 0);
 
 	g_autofree gchar *uri = g_strdup((gchar *) gtk_selection_data_get_data(data));
-	g_autofree gchar *unescaped = NULL;
 	g_autoptr(GFile) file = NULL;
 	g_autoptr(GError) err = NULL;
 
 	if (g_str_has_prefix(uri, "file://")) {
-		unescaped = g_uri_unescape_string(uri, NULL);
-		g_strstrip(unescaped); // Make sure there's nothing silly like a trailing newline
-		file = g_file_new_for_uri(unescaped);
+		g_strstrip(uri); // Make sure there's nothing silly like a trailing newline
+
+		file = g_file_new_for_uri(uri);
 
 		if (!g_file_trash(file, NULL, &err)) {
 			trash_notify_try_send(_("Trash Error"), err->message, "dialog-error-symbolic");
 			g_critical("%s:%d: Error moving file to trash: %s", __BASE_FILE__, __LINE__, err->message);
+			gtk_drag_finish(context, FALSE, TRUE, time);
 			return;
 		}
 	}

--- a/src/panel/applets/trash/trash_info.c
+++ b/src/panel/applets/trash/trash_info.c
@@ -14,7 +14,6 @@
 enum {
 	PROP_NAME = 1,
 	PROP_DISPLAY_NAME,
-	PROP_URI,
 	PROP_RESTORE_PATH,
 	PROP_ICON,
 	PROP_SIZE,
@@ -32,7 +31,6 @@ struct _TrashInfo {
 
 	const gchar *name;
 	const gchar *display_name;
-	const gchar *uri;
 	const gchar *restore_path;
 
 	GIcon *icon;
@@ -52,7 +50,6 @@ static void trash_info_finalize(GObject *obj) {
 
 	g_free((gchar *) self->name);
 	g_free((gchar *) self->display_name);
-	g_free((gchar *) self->uri);
 	g_free((gchar *) self->restore_path);
 	g_object_unref(self->icon);
 	g_date_time_unref(self->deleted_time);
@@ -72,9 +69,6 @@ static void trash_info_get_property(GObject *obj, guint prop_id, GValue *value, 
 			break;
 		case PROP_DISPLAY_NAME:
 			g_value_set_string(value, trash_info_get_display_name(self));
-			break;
-		case PROP_URI:
-			g_value_set_string(value, trash_info_get_uri(self));
 			break;
 		case PROP_RESTORE_PATH:
 			g_value_set_string(value, trash_info_get_restore_path(self));
@@ -111,9 +105,6 @@ static void trash_info_set_property(GObject *obj, guint prop_id, const GValue *v
 			break;
 		case PROP_DISPLAY_NAME:
 			self->display_name = g_value_get_string(value);
-			break;
-		case PROP_URI:
-			self->uri = g_value_get_string(value);
 			break;
 		case PROP_RESTORE_PATH:
 			self->restore_path = g_value_get_string(value);
@@ -155,13 +146,6 @@ static void trash_info_class_init(TrashInfoClass *klazz) {
 		"display-name",
 		"Display name",
 		"The display name of the file",
-		NULL,
-		G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
-
-	props[PROP_URI] = g_param_spec_string(
-		"uri",
-		"URI",
-		"The URI to the file",
 		NULL,
 		G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 
@@ -212,13 +196,12 @@ static void trash_info_init(TrashInfo *self) {
 /**
  * trash_info_new:
  * @info: a #GFileInfo
- * @uri: (transfer full): a URI to the file
  *
  * Creates a new #TrashInfo object.
  *
  * Returns: a new #TrashInfo object
  */
-TrashInfo *trash_info_new(GFileInfo *info, const gchar *uri) {
+TrashInfo *trash_info_new(GFileInfo *info) {
 	GIcon *icon;
 
 	icon = g_file_info_get_icon(info);
@@ -227,7 +210,6 @@ TrashInfo *trash_info_new(GFileInfo *info, const gchar *uri) {
 		TRASH_TYPE_INFO,
 		"name", g_strdup(g_file_info_get_name(info)),
 		"display-name", g_strdup(g_file_info_get_display_name(info)),
-		"uri", g_strdup(uri),
 		"restore-path", g_strdup(g_file_info_get_attribute_byte_string(info, G_FILE_ATTRIBUTE_TRASH_ORIG_PATH)),
 		"icon", g_icon_serialize(g_object_ref(icon)),
 		"size", g_file_info_get_size(info),
@@ -260,18 +242,6 @@ const gchar *trash_info_get_name(TrashInfo *self) {
  */
 const gchar *trash_info_get_display_name(TrashInfo *self) {
 	return g_strdup(self->display_name);
-}
-
-/**
- * trash_info_get_uri:
- * @self: a #TrashInfo
- *
- * Gets the URI for the file.
- *
- * Returns: (transfer full): the URI to the file
- */
-const gchar *trash_info_get_uri(TrashInfo *self) {
-	return g_strdup(self->uri);
 }
 
 /**

--- a/src/panel/applets/trash/trash_info.h
+++ b/src/panel/applets/trash/trash_info.h
@@ -19,15 +19,13 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE(TrashInfo, trash_info, TRASH, INFO, GObject)
 
-TrashInfo *trash_info_new(GFileInfo *info, const char *uri);
+TrashInfo *trash_info_new(GFileInfo *info);
 
 /* Property getters */
 
 const gchar *trash_info_get_name(TrashInfo *self);
 
 const gchar *trash_info_get_display_name(TrashInfo *self);
-
-const gchar *trash_info_get_uri(TrashInfo *self);
 
 const gchar *trash_info_get_restore_path(TrashInfo *self);
 

--- a/src/panel/applets/trash/trash_item_row.h
+++ b/src/panel/applets/trash/trash_item_row.h
@@ -21,7 +21,9 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE(TrashItemRow, trash_item_row, TRASH, ITEM_ROW, GtkListBoxRow)
 
-TrashItemRow *trash_item_row_new(TrashInfo *trash_info);
+TrashItemRow *trash_item_row_new(GFile *file, TrashInfo *trash_info);
+
+GFile *trash_item_row_get_file(TrashItemRow *self);
 
 TrashInfo *trash_item_row_get_info(TrashItemRow *self);
 

--- a/src/panel/applets/trash/trash_popover.c
+++ b/src/panel/applets/trash/trash_popover.c
@@ -126,12 +126,12 @@ static void settings_clicked(GtkButton *button, TrashPopover *self) {
 	}
 }
 
-static void trash_added(TrashManager *manager, TrashInfo *trash_info, TrashPopover *self) {
+static void trash_added(TrashManager *manager, GFile *file, TrashInfo *trash_info, TrashPopover *self) {
 	(void) manager;
 	TrashItemRow *row;
 	gint count;
 
-	row = trash_item_row_new(trash_info);
+	row = trash_item_row_new(file, trash_info);
 
 	gtk_list_box_insert(GTK_LIST_BOX(self->file_box), GTK_WIDGET(row), -1);
 
@@ -143,23 +143,25 @@ static void trash_added(TrashManager *manager, TrashInfo *trash_info, TrashPopov
 	g_signal_emit(self, signals[TRASH_FILLED], 0, NULL);
 }
 
-static void foreach_item_cb(TrashItemRow *row, gchar *uri) {
-	TrashInfo *info;
-	g_autofree const gchar *info_uri;
+static void foreach_item_cb(TrashItemRow *row, GFile *file) {
+	g_autofree const gchar *row_uri, *uri;
+	g_autoptr(GFile) row_file;
 
-	info = trash_item_row_get_info(row);
-	info_uri = trash_info_get_uri(info);
+	row_file = trash_item_row_get_file(row);
+	row_uri = g_file_get_uri(row_file);
 
-	if (g_strcmp0(info_uri, uri) == 0) {
+	uri = g_file_get_uri(file);
+
+	if (g_strcmp0(row_uri, uri) == 0) {
 		gtk_widget_destroy(GTK_WIDGET(row));
 	}
 }
 
-static void trash_removed(TrashManager *manager, gchar *name, TrashPopover *self) {
+static void trash_removed(TrashManager *manager, GFile *file, TrashPopover *self) {
 	(void) manager;
 	gint count;
 
-	gtk_container_foreach(GTK_CONTAINER(self->file_box), (GtkCallback) foreach_item_cb, name);
+	gtk_container_foreach(GTK_CONTAINER(self->file_box), (GtkCallback) foreach_item_cb, file);
 
 	gtk_list_box_invalidate_sort(GTK_LIST_BOX(self->file_box));
 


### PR DESCRIPTION
## Description

As long as we have valid GFile objects, file operations won't fail. The trick is getting correct GFiles when initially scanning the trash directory, because GLib in its infinite wisdom makes GFileEnumerator return a list of GFileInfo, not GFile. And file name/path URI encoding is a mess.

Tested with:
- Files with % in the name, both on local and removable drives
- Files without % in the name, both on local and removable drives
- Files with spaces in the name, both on local and removable drives
- Files without spaces in the name, both on local and removable drives
- Files only consisting of letters, both on local and removable drives

Tested by:
- Drag-n-dropping file to trash applet button
- Trashing file in file manager
- Permanently deleting file via applet
- Restoring file via applet

Fixes #409

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
