### PR TITLE
Work around more SN/dbusmenu quirks

### DIFF
--- a/src/panel/applets/tray/DBusMenu.vala
+++ b/src/panel/applets/tray/DBusMenu.vala
@@ -91,7 +91,7 @@ public class DBusMenu : Object {
 			all_nodes.set(id, node);
 		}
 
-		if (v_children.is_container() && v_children.n_children() > 0) {
+		if (v_children.get_type().is_array() && v_children.n_children() > 0) {
 			var new_children = new List<DBusMenuNode>();
 
 			VariantIter it = v_children.iterator();
@@ -119,11 +119,13 @@ public class DBusMenu : Object {
 	}
 
 	private void update_node_properties(DBusMenuNode node, Variant props) {
-		VariantIter prop_it = props.iterator();
-		string key;
-		Variant value;
-		while (prop_it.next("{sv}", out key, out value)) {
-			node.update_property(key, value);
+		VariantIter it = props.iterator();
+		for (var prop = it.next_value(); prop != null; prop = it.next_value()) {
+			if (prop.is_of_type(new VariantType("{sv}"))) {
+				string key = prop.get_child_value(0).get_string();
+				Variant value = prop.get_child_value(1);
+				node.update_property(key, value);
+			}
 		}
 	}
 

--- a/src/panel/applets/tray/DBusMenuNode.vala
+++ b/src/panel/applets/tray/DBusMenuNode.vala
@@ -47,6 +47,10 @@ public class DBusMenuNode : Object {
 		for (int i = 0; i < new_children.length(); i++) {
 			var item = new_children.nth_data(i).item;
 
+			if (item.parent != null) {
+				item.parent.remove(item);
+			}
+
 			if (item.parent != submenu) {
 				submenu.add(item);
 			}

--- a/src/panel/applets/tray/TrayItem.vala
+++ b/src/panel/applets/tray/TrayItem.vala
@@ -213,11 +213,11 @@ internal class TrayItem : Gtk.EventBox {
 
 				if (markup != "") {
 					set_tooltip_markup(markup);
-					return;
 				} else {
 					set_tooltip_text(title);
-					return;
 				}
+				
+				return;
 			} else if (dbus_properties.tool_tip.is_of_type(VariantType.STRING)) {
 				// quirk for TeamViewer
 				set_tooltip_text(dbus_properties.tool_tip.get_string());


### PR DESCRIPTION
## Description

Adds a quirk for tooltips of type string (TeamViewer). That resolves #429.

Also adds some additional checks for containers to potentially work around #437.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
