### PR TITLE
Add setting for tray icon scaling

### DIFF
--- a/src/panel/applets/tray/TrayApplet.vala
+++ b/src/panel/applets/tray/TrayApplet.vala
@@ -79,11 +79,8 @@ public class TrayApplet : Budgie.Applet {
 			layout.set_spacing(settings.get_int("spacing"));
 		});
 		settings.changed["scaling"].connect((key) => {
-			if (settings.get_boolean("scaling")) {
-				items.get_values().foreach((item) => item.resize(panel_size));
-			} else {
-				items.get_values().foreach((item) => item.resize(36));
-			}
+			var size = settings.get_boolean("scaling") ? panel_size : 36;
+			items.get_values().foreach((item) => item.resize(size));
 		});
 
 		items = new HashTable<string, TrayItem>(str_hash, str_equal);

--- a/src/panel/applets/tray/TrayApplet.vala
+++ b/src/panel/applets/tray/TrayApplet.vala
@@ -22,9 +22,13 @@ public class TraySettings : Gtk.Grid {
 	[GtkChild]
 	private unowned Gtk.SpinButton? spinbutton_spacing;
 
+	[GtkChild]
+	private unowned Gtk.Switch? switch_scaling;
+
 	public TraySettings(Settings? settings) {
 		this.settings = settings;
 		settings.bind("spacing", spinbutton_spacing, "value", SettingsBindFlags.DEFAULT);
+		settings.bind("scaling", switch_scaling, "active", SettingsBindFlags.DEFAULT);
 	}
 }
 
@@ -73,6 +77,13 @@ public class TrayApplet : Budgie.Applet {
 		settings = get_applet_settings(uuid);
 		settings.changed["spacing"].connect((key) => {
 			layout.set_spacing(settings.get_int("spacing"));
+		});
+		settings.changed["scaling"].connect((key) => {
+			if (settings.get_boolean("scaling")) {
+				items.get_values().foreach((item) => item.resize(panel_size));
+			} else {
+				items.get_values().foreach((item) => item.resize(36));
+			}
 		});
 
 		items = new HashTable<string, TrayItem>(str_hash, str_equal);
@@ -191,9 +202,11 @@ public class TrayApplet : Budgie.Applet {
 
 	public override void panel_size_changed(int panel, int icon, int small_icon) {
 		panel_size = panel;
-		items.get_values().foreach((item)=>{
-			item.resize(panel);
-		});
+		if (settings.get_boolean("scaling")) {
+			items.get_values().foreach((item)=>{
+				item.resize(panel);
+			});
+		}
 	}
 
 	public override bool supports_settings() {

--- a/src/panel/applets/tray/com.solus-project.tray.gschema.xml
+++ b/src/panel/applets/tray/com.solus-project.tray.gschema.xml
@@ -6,5 +6,10 @@
       <summary>Space between icons</summary>
       <description>How large to make the space between icons, in pixels</description>
     </key>
+    <key type="b" name="scaling">
+      <default>false</default>
+      <summary>Scale icons with panel size</summary>
+      <description>Whether icons in the tray should scale along with the panel size.</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/panel/applets/tray/settings.ui
+++ b/src/panel/applets/tray/settings.ui
@@ -10,6 +10,8 @@
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="hexpand">True</property>
+    <property name="row_spacing">4</property>
+    <property name="column_spacing">4</property>
     <child>
       <object class="GtkLabel" id="label1">
         <property name="visible">True</property>
@@ -36,6 +38,29 @@
       <packing>
         <property name="left_attach">1</property>
         <property name="top_attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Scale icons with panel size</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="switch_scaling">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">end</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">1</property>
       </packing>
     </child>
   </template>


### PR DESCRIPTION
## Description

Icon scaling in the system tray is now disabled by default, and can be enabled by the associated switch in the applet settings. Resolves #435.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
