### PR TITLE
Add xdg-desktop-portal config

### DIFF
--- a/data/budgie-portals.conf
+++ b/data/budgie-portals.conf
@@ -1,0 +1,3 @@
+[preferred]
+# Use xdg-desktop-portal-gtk for every portal interface
+default=gtk

--- a/data/meson.build
+++ b/data/meson.build
@@ -15,3 +15,8 @@ install_data(
     version_file,
     install_dir: join_paths(datadir, 'budgie')
 )
+
+install_data(
+    'budgie-portals.conf',
+    install_dir: join_paths(datadir, 'xdg-desktop-portal')
+)


### PR DESCRIPTION
## Description

Defaults to xdg-desktop-portal-gtk for all portals. Resolves #436. xdg-desktop-portal v1.17.0 isn't stable, so this PR is untested.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
