### PR TITLE
Make dark theme switch apply to color scheme pref

### DIFF
--- a/src/daemon/settings.vala
+++ b/src/daemon/settings.vala
@@ -22,6 +22,13 @@ namespace Budgie {
 		LEFT = 1 << 0,
 		TRADITIONAL = 1 << 1,
 	}
+
+	private enum ColorScheme {
+		DEFAULT,
+		PREFER_DARK,
+		PREFER_LIGHT
+	}
+
 	/**
 	* The SettingsManager currently only has a very simple job, and looks for
 	* session wide settings changes to respond to
@@ -43,6 +50,7 @@ namespace Budgie {
 		private Settings? gnome_session_settings = null;
 		private Settings? gnome_sound_settings = null;
 		private Settings? gnome_wm_settings = null;
+		private Settings? panel_settings = null;
 		private Settings? raven_settings = null;
 		private Settings? wm_settings = null;
 		private Settings? xoverrides = null;
@@ -74,6 +82,7 @@ namespace Budgie {
 			gnome_session_settings = new Settings("org.gnome.desktop.session");
 			gnome_sound_settings = new Settings("org.gnome.desktop.sound");
 			gnome_wm_settings = new Settings("org.gnome.desktop.wm.preferences");
+			panel_settings = new Settings("com.solus-project.budgie-panel");
 			raven_settings = new Settings("com.solus-project.budgie-raven");
 			xoverrides = new Settings("org.gnome.settings-daemon.plugins.xsettings");
 			wm_settings = new Settings("com.solus-project.budgie-wm");
@@ -88,6 +97,10 @@ namespace Budgie {
 
 			enforce_mutter_settings(); // Call enforce mutter settings so we ensure we transition our Mutter settings over to BudgieWM
 			raven_settings.changed["allow-volume-overdrive"].connect(this.on_raven_sound_overdrive_change);
+
+
+			panel_settings.changed["dark-theme"].connect((key) => apply_dark_theme_pref());
+			apply_dark_theme_pref();
 
 			gnome_session_settings.changed["idle-delay"].connect(this.update_idle_delay);
 			gnome_power_settings.changed["idle-dim"].connect(this.update_idle_dim);
@@ -440,6 +453,11 @@ namespace Budgie {
 			if (!get_caffeine_mode()) { // If Caffeine Mode is off
 				default_idle_dim = gnome_power_settings.get_boolean("idle-dim");
 			}
+		}
+
+		private void apply_dark_theme_pref() {
+			var scheme = panel_settings.get_boolean("dark-theme") ? ColorScheme.PREFER_DARK : ColorScheme.PREFER_LIGHT;
+			gnome_desktop_settings.set_enum("color-scheme", scheme);
 		}
 	}
 }


### PR DESCRIPTION
## Description

Adds a few LoC into the daemon that synchronize the dark theme dconf setting with GNOME's freedesktop color scheme dconf setting.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
