### PR TITLE
Simplify Raven notification group

### DIFF
--- a/src/daemon/notifications/popup.vala
+++ b/src/daemon/notifications/popup.vala
@@ -301,7 +301,8 @@ namespace Budgie.Notifications {
 				margin_bottom = 5,
 				margin_right = 16,
 				halign = Gtk.Align.START,
-				hexpand = true
+				hexpand = true,
+				use_markup = true
 			};
 			title_label.get_style_context().add_class("notification-title");
 

--- a/src/lib/notification.vala
+++ b/src/lib/notification.vala
@@ -73,9 +73,15 @@
 			HashTable<string, Variant> hints,
 			uint expire_timeout
 		) {
+			var name = app_name;
+
+			if (("budgie" in name) && ("caffeine" in app_icon)) { // Caffeine Notification
+				name = _("Caffeine Mode");
+			}
+
 			Object (
 				id: id,
-				app_name: app_name,
+				app_name: name,
 				app_icon: app_icon,
 				summary: summary,
 				body: body,

--- a/src/panel/com.solus-project.budgie-panel.gschema.xml
+++ b/src/panel/com.solus-project.budgie-panel.gschema.xml
@@ -118,7 +118,7 @@
     </key>
 
     <key type="as" name="spam-apps">
-      <default>['Spotify', 'Lollypop', 'audacious', 'org.buddiesofbudgie.BudgieDesktopNmApplet.desktop', 'lollypop.desktop', 'budgie-power-panel', 'budgie-printer-panel', 'gnome-power-panel', 'gnome-printer-panel', 'nm-applet']</default>
+      <default>['Spotify', 'Lollypop', 'audacious', 'com.spotify.Client', 'org.buddiesofbudgie.BudgieDesktopNmApplet', 'lollypop', 'budgie-power-panel', 'budgie-printer-panel', 'gnome-power-panel', 'gnome-printer-panel', 'nm-applet']</default>
       <summary>Spam Apps</summary>
       <description>Notifications send by these apps will not be displayed in Raven.</description>
     </key>

--- a/src/raven/notifications_group.vala
+++ b/src/raven/notifications_group.vala
@@ -21,7 +21,7 @@ namespace Budgie {
 		private Gtk.ListBox noti_box;
 
 		public string app_name { get; construct; }
-		public string app_icon { get; construct; }
+		public Gtk.Image image { get; construct; }
 		public uint tokeep { get; construct set; }
 		public NotificationSort noti_sort_mode { get; construct set; default = NEW_OLD; }
 		public int noti_count { get; private set; default = 0; }
@@ -55,11 +55,10 @@ namespace Budgie {
 			var header = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0); // Create our Notification header
 			header.get_style_context().add_class("raven-notifications-group-header");
 
-			var app_image = new Gtk.Image.from_icon_name(app_icon, Gtk.IconSize.DND) {
-				halign = Gtk.Align.START,
-				margin_end = 5,
-				pixel_size = 32, // Really ensure it's 32x32
-			};
+			var app_icon = image;
+			app_icon.halign = Gtk.Align.START;
+			app_icon.margin_end = 5;
+			app_icon.pixel_size = 32;
 
 			name_label = new Gtk.Label(app_name) {
 				ellipsize = Pango.EllipsizeMode.END,
@@ -77,7 +76,7 @@ namespace Budgie {
 
 			dismiss_button.clicked.connect(dismiss_all);
 
-			header.pack_start(app_image, false, false, 0);
+			header.pack_start(app_icon, false, false, 0);
 			header.pack_start(name_label, false, false, 0);
 			header.pack_end(dismiss_button, false, false, 0);
 
@@ -85,16 +84,10 @@ namespace Budgie {
 			pack_start(noti_box);
 		}
 
-		public NotificationGroup(string c_app_icon, string c_app_name, NotificationSort sort_mode, uint keep) {
-			var name = c_app_name;
-
-			if (("budgie" in name) && ("caffeine" in c_app_icon)) { // Caffeine Notification
-				name = _("Caffeine Mode");
-			}
-
+		public NotificationGroup(Budgie.Notification notification, NotificationSort sort_mode, uint keep) {
 			Object(
-				app_name: name,
-				app_icon: c_app_icon,
+				app_name: notification.app_name,
+				image: notification.image,
 				tokeep: keep,
 				noti_sort_mode: sort_mode,
 				orientation: Gtk.Orientation.VERTICAL,

--- a/src/raven/notifications_group.vala
+++ b/src/raven/notifications_group.vala
@@ -13,7 +13,7 @@ namespace Budgie {
 	/**
 	 * NotificationGroup is a group of notifications.
 	 */
-	public class NotificationGroup : Gtk.Box {
+	public class NotificationGroup : Gtk.ListBoxRow {
 		private HashTable<uint32, NotificationWidget> notifications;
 
 		private Gtk.Label name_label;
@@ -32,13 +32,7 @@ namespace Budgie {
 		public signal void dismissed_notification(uint32 id);
 
 		construct {
-			can_focus = false; // Disable focus to prevent scroll on click
-			focus_on_click = false;
-
 			get_style_context().add_class("raven-notifications-group");
-
-			// Intentially omit _end because it messes with alignment of dismiss buttons
-			margin = 4;
 
 			notifications = new HashTable<uint32, NotificationWidget>(direct_hash, direct_equal);
 
@@ -80,8 +74,14 @@ namespace Budgie {
 			header.pack_start(name_label, false, false, 0);
 			header.pack_end(dismiss_button, false, false, 0);
 
-			pack_start(header);
-			pack_start(noti_box);
+			var box = new Gtk.Box(Gtk.Orientation.VERTICAL, 4) {
+				margin = 4,
+			};
+
+			box.pack_start(header);
+			box.pack_start(noti_box);
+
+			add(box);
 		}
 
 		public NotificationGroup(Budgie.Notification notification, NotificationSort sort_mode, uint keep) {
@@ -90,8 +90,10 @@ namespace Budgie {
 				image: notification.image,
 				tokeep: keep,
 				noti_sort_mode: sort_mode,
-				orientation: Gtk.Orientation.VERTICAL,
-				spacing: 4
+				activatable: false,
+				selectable: false,
+				can_focus: false,
+				focus_on_click: false
 			);
 		}
 
@@ -111,9 +113,7 @@ namespace Budgie {
 			update_count();
 
 			widget.closed_individually.connect(() => { // When this notification is closed
-				uint n_id = (uint) notification.id;
-				remove_notification(n_id);
-				dismissed_notification(n_id);
+				remove_notification((uint) notification.id);
 			});
 		}
 

--- a/src/raven/notifications_group.vala
+++ b/src/raven/notifications_group.vala
@@ -87,7 +87,7 @@ namespace Budgie {
 		public NotificationGroup(Budgie.Notification notification, NotificationSort sort_mode, uint keep) {
 			Object(
 				app_name: notification.app_name,
-				image: notification.image,
+				image: notification.app_image ?? notification.image ?? new Gtk.Image.from_icon_name("applications-internet", Gtk.IconSize.DND),
 				tokeep: keep,
 				noti_sort_mode: sort_mode,
 				activatable: false,

--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -268,11 +268,10 @@ namespace Budgie {
 				listbox.add(group);
 
 				group.dismissed_group.connect((name) => { // When we dismiss the group
-					var parent = group.get_parent();
-					parent.destroy();
 					notification_count -= group.noti_count;
 					update_child_count();
 					Raven.get_instance().ReadNotifications(); // Update our counter
+					group.destroy();
 				});
 
 				group.dismissed_notification.connect((id) => {
@@ -291,26 +290,20 @@ namespace Budgie {
 		}
 
 		private NotificationGroup? get_notification_group(string name) {
-			NotificationGroup? group = null;
-
-			foreach (var child in listbox.get_children()) {
-				var row = ((Gtk.ListBoxRow) child).get_child() as NotificationGroup;
-
-				if (row.app_name != name) continue;
-
-				group = row;
-				break;
+			foreach (var group in listbox.get_children()) {
+				if (((NotificationGroup) group).app_name == name) {
+					return group as NotificationGroup;
+				}
 			}
 
-			return group;
+			return null;
 		}
 
 		void adjust_max_per_group(uint newmax, bool trim) {
-			foreach (var child in listbox.get_children()) {
-				var group = ((Gtk.Bin) child).get_child() as NotificationGroup;
-				group.set_group_max_notifications(max_per_group);
+			foreach (var group in listbox.get_children()) {
+				((NotificationGroup) group).set_group_max_notifications(max_per_group);
 				if (trim) {
-					group.limit_notifications();
+					((NotificationGroup) group).limit_notifications();
 				}
 			}
 		}

--- a/src/raven/notifications_view.vala
+++ b/src/raven/notifications_view.vala
@@ -85,12 +85,11 @@ namespace Budgie {
 		private Gtk.Image image_notifications_enabled = new Gtk.Image.from_icon_name("notification-alert-symbolic", Gtk.IconSize.MENU);
 
 		private bool do_not_disturb { get; private set; default = false; }
-		private bool performing_clear_all { get; private set; default = false; }
 		private NotificationSort sort_mode { get; private set; default = NEW_OLD; }
 
 		private Dispatcher dispatcher;
 		private HashTable<uint32, Budgie.Notification> notifications;
-		private HashTable<string, NotificationGroup> notification_groups;
+		private int notification_count;
 
 		private Settings budgie_settings;
 		private Settings raven_settings;
@@ -130,7 +129,7 @@ namespace Budgie {
 			pack_start(header, false, false, 0);
 
 			notifications = new HashTable<uint32, Budgie.Notification>(direct_hash, direct_equal);
-			notification_groups = new HashTable<string, NotificationGroup>(str_hash, str_equal);
+			notification_count = 0;
 
 			var scrolledwindow = new Gtk.ScrolledWindow(null, null);
 			scrolledwindow.get_style_context().add_class("raven-background");
@@ -246,97 +245,78 @@ namespace Budgie {
 		}
 
 		private void on_notification_closed(uint32 id, string app_name, NotificationCloseReason reason) {
-			var notification = this.notifications[id];
-			if (notification == null) {
-				this.notifications.remove(id);
-				return;
-			}
+			Budgie.Notification? notification;
+			if (!notifications.steal_extended(id, null, out notification)) return;
 
 			// We only care about expired notifications so we can add them to the
 			// notifications view in Raven.
-			if (reason == NotificationCloseReason.EXPIRED) {
-				string[] spam_apps = budgie_settings.get_strv(Budgie.ROOT_KEY_SPAM_APPS);
-				string[] spam_categories = budgie_settings.get_strv(Budgie.ROOT_KEY_SPAM_CATEGORIES);
+			if (reason != NotificationCloseReason.EXPIRED) return;
 
-				var app_id = (notification.app_id != null) ? notification.app_id : app_name;
-				bool should_store = !(notification.category != null && notification.category in spam_categories) &&
-									!(app_id != null && app_id in spam_apps);
-				if (should_store) {
-					// Get an icon to use for this application group
-					string app_icon = ((app_name != "") && (app_name != null)) ? app_name : "applications-internet"; // Default app_icon to being the name of the app, or fallback
+			string[] spam_apps = budgie_settings.get_strv(Budgie.ROOT_KEY_SPAM_APPS);
+			string[] spam_categories = budgie_settings.get_strv(Budgie.ROOT_KEY_SPAM_CATEGORIES);
 
-					if ((notification.image != null) && (notification.image.icon_name != null)) { // If we have an image set
-						app_icon = notification.image.icon_name; // Use the icon specified in the image
-					}
+			var app_id = (notification.app_id != null) ? notification.app_id : app_name;
+			bool should_store = !(notification.category != null && notification.category in spam_categories) &&
+								!(app_id != null && app_id in spam_apps);
 
-					app_icon = app_icon.down();
+			if (!should_store) return;
 
-					if (app_icon == "image-invalid") {
-						app_icon = "applications-internet";
-					}
+			// Look for an existing group. If one doesn't exist, create it
+			var group = get_notification_group(app_name);
+			if (group == null) {
+				group = new NotificationGroup(notification, sort_mode, max_per_group);
+				listbox.add(group);
 
-					var name = notification.app_name;
-					if (notification.app_info != null) {
-						if (notification.app_info.has_key("Icon")) {
-							app_icon = notification.app_info.get_string("Icon");
-						}
-						if (notification.app_info.has_key("Name")) {
-							name = notification.app_info.get_string("Name");
-						}
-					}
-
-					// Look for an existing group. If one doesn't exist, create it
-					var group = this.notification_groups.lookup(name);
-					if (group == null) {
-						group = new NotificationGroup(app_icon, name, sort_mode, max_per_group);
-						this.listbox.add(group);
-
-						group.dismissed_group.connect((name) => { // When we dismiss the group
-							var parent = group.get_parent();
-							listbox.remove(parent);
-							parent.destroy();
-
-							/**
-							* If we're not performing a clear all, remove this entry from notifications list and update our child count
-							* Performing a remove seems to affect a .foreach call, so best to avoid this.
-							*/
-							if (!performing_clear_all) {
-								notification_groups.remove(name);
-								update_child_count();
-							}
-
-							Raven.get_instance().ReadNotifications(); // Update our counter
-						});
-
-						group.dismissed_notification.connect((id) => {
-							update_child_count();
-							Raven.get_instance().ReadNotifications(); // Update our counter
-						});
-
-						notification_groups.insert(name, group);
-					}
-
-					// Add the notification to the group, and notify Raven
-					group.add_notification(id, notification);
-					group.show_all();
+				group.dismissed_group.connect((name) => { // When we dismiss the group
+					var parent = group.get_parent();
+					parent.destroy();
+					notification_count -= group.noti_count;
 					update_child_count();
-					Raven.get_instance().UnreadNotifications();
-				}
+					Raven.get_instance().ReadNotifications(); // Update our counter
+				});
+
+				group.dismissed_notification.connect((id) => {
+					notification_count--;
+					update_child_count();
+					Raven.get_instance().ReadNotifications(); // Update our counter
+				});
 			}
-			this.notifications.remove(id);
+
+			// Add the notification to the group, and notify Raven
+			group.add_notification(id, notification);
+			group.show_all();
+			notification_count++;
+			update_child_count();
+			Raven.get_instance().UnreadNotifications();
+		}
+
+		private NotificationGroup? get_notification_group(string name) {
+			NotificationGroup? group = null;
+
+			foreach (var child in listbox.get_children()) {
+				var row = ((Gtk.ListBoxRow) child).get_child() as NotificationGroup;
+
+				if (row.app_name != name) continue;
+
+				group = row;
+				break;
+			}
+
+			return group;
 		}
 
 		void adjust_max_per_group(uint newmax, bool trim) {
-			notification_groups.foreach((app_name, notification_group) => {
-				notification_group.set_group_max_notifications(max_per_group);
+			foreach (var child in listbox.get_children()) {
+				var group = ((Gtk.Bin) child).get_child() as NotificationGroup;
+				group.set_group_max_notifications(max_per_group);
 				if (trim) {
-					notification_group.limit_notifications();
+					group.limit_notifications();
 				}
-			});
+			}
 		}
 
 		void check_notification_allocation(uint len) {
-			uint n_groups = notification_groups.length;
+			uint n_groups = listbox.get_children().length();
 			uint newmax = max_per_group;
 			bool trim = false;
 			if (n_groups == 0) {
@@ -360,38 +340,26 @@ namespace Budgie {
 		}
 
 		void update_child_count() {
-			uint len = 0;
-
-			if (notification_groups.length != 0) {
-				notification_groups.foreach((app_name, notification_group) => { // For each notifications list
-					len += notification_group.noti_count; // Add this notification group count
-				});
-			}
-
 			string? text = null;
-			if (len > 1) {
-				text = _("%u unread notifications").printf(len);
-			} else if (len == 1) {
-				text = _("1 unread notification");
+
+			if (notification_count > 0) {
+				text = ngettext("%u unread notification", "%u unread notifications", notification_count);
 			} else {
 				text = _("No unread notifications");
 			}
 
-			Raven.get_instance().set_notification_count(len);
+			Raven.get_instance().set_notification_count(notification_count);
 			header.text = text;
-			clear_notifications_button.set_visible((len >= 1)); // Only show clear notifications button if we actually have notifications
-			check_notification_allocation(len);
+			clear_notifications_button.set_visible((notification_count > 0)); // Only show clear notifications button if we actually have notifications
+			check_notification_allocation(notification_count);
 		}
 
 		void clear_all() {
-			performing_clear_all = true;
+			foreach (var child in listbox.get_children()) {
+				child.destroy();
+			}
 
-			notification_groups.foreach((app_name, notification_group) => {
-				notification_group.dismiss_all();
-			});
-
-			notification_groups.remove_all(); // Ensure we're resetting notifications_list
-			performing_clear_all = false;
+			notification_count = 0;
 			update_child_count();
 			Raven.get_instance().ReadNotifications();
 		}

--- a/src/theme/common/_raven.scss
+++ b/src/theme/common/_raven.scss
@@ -28,7 +28,7 @@
         &.middle { border-bottom-style: none; }  // applet background between two headers
     }
 
-    .raven-notifications-view > .raven-background > .frame > list > row.activatable {
+    .raven-notifications-view > .raven-background > .frame > list {
         @extend %reset_style;
 
         .raven-notifications-group {
@@ -37,7 +37,7 @@
             }
 
             // single notification
-            > list > row.activatable {
+            box > list > row.activatable {
                 @extend %reset_style;
 
                 padding: 3px 6px;


### PR DESCRIPTION
## Description
This does a couple of things. First, when constructing a notification group, just get the image directly from our Notification object. We did all the work to get the correct image, let's actually use it.

Secondly, remove our HashTable mapping application name to notification group. We don't need it; anything it was used for we can get from the ListBox. This avoids having to keep track of groups in multiple data structures (the table and the list box). This makes the code easier to maintain, and slightly more memory efficient.

The NotificationGroup widget has been changed to a `Gtk.ListBoxRow` to make it easier to find and remove groups from the view.

Lastly, switch to `ngettext` to build the text for the notification view header instead of an if/elseif chain.

Fixes #450 

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
