### PR TITLE
notifications: Try to guess app id if getting from hints fails

### DIFF
--- a/src/lib/notification.vala
+++ b/src/lib/notification.vala
@@ -267,9 +267,13 @@
 
 		private Gtk.Image? get_appinfo_image(Gtk.IconSize size, string? fallback) {
 			if (app_info == null) {
-				var fallback_image = new Gtk.Image.from_icon_name(fallback, size);
-				var invalid_image = (fallback_image == null) || (fallback_image.icon_name == null) || (fallback_image.icon_name == "image-missing") || (fallback_image.icon_name == "");
-				return invalid_image ? null : fallback_image;
+				var theme = Gtk.IconTheme.get_default();
+
+				if (!theme.has_icon(fallback)) {
+					return null;
+				}
+
+				return new Gtk.Image.from_icon_name(fallback, size);
 			}
 
 			var app_icon_name = app_info.get_string("Icon"); // Use the Icon from the respective DesktopAppInfo or fallback to generic applications-internet

--- a/src/lib/notification.vala
+++ b/src/lib/notification.vala
@@ -115,15 +115,27 @@
 				category = variant.get_string();
 			}
 
-			// Set the application ID and app info
+			// Try to set the application ID and app info
 			if ((variant = hints.lookup("desktop-entry")) != null && variant.is_of_type(VariantType.STRING)) {
 				app_id = variant.get_string();
 				app_id.replace(".desktop", "");
 				app_info = new DesktopAppInfo("%s.desktop".printf(app_id));
-
-				if (app_info != null) app_name = app_info.get_string("Name") ?? app_name;
 			}
 
+			// Because following specs is a lost art, sometimes the desktop-entry
+			// value does not correspond to the desktop file. So, try to best-guess
+			// the desktop id instead.
+			if (app_info == null) {
+				app_id = app_name.replace(" ", "-").down();
+				app_info = new DesktopAppInfo("%s.desktop".printf(app_id));
+			}
+
+			// Make sure we have the best app name
+			if (app_info != null) {
+				app_name = app_info.get_string("Name") ?? app_name;
+			}
+
+			// Try to get the application's image
 			app_image = get_appinfo_image(Gtk.IconSize.DND, app_id.down());
 
 			bool image_found = false;
@@ -272,4 +284,4 @@
 			return null;
 		}
 	}
- }
+}


### PR DESCRIPTION
## Description

The notification spec states that the `desktop-entry` hint should be the prefix of the Desktop Application Info file. However, because of the push to have fully-qualified app ID's, some applications now have a mismatch between the ID and the desktop file, meaning the hint cannot be used for that application.

In cases where the hint fails, try to guess the ID using the application's name given to us from DBus.

It seems to fix https://github.com/BuddiesOfBudgie/budgie-desktop/issues/477.

### Original description:

The spec states that the image data from a notification should be used before the application icon or any other icon. This change should reflect that.

It seems to fix #477. Nemo and Twitch Streamlink notifications now display properly in Raven on my system.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
