### PR TITLE
Use user-space variables to pass temporary screenshot data

### DIFF
--- a/src/daemon/screenshot.vala
+++ b/src/daemon/screenshot.vala
@@ -66,7 +66,7 @@ namespace BudgieScr {
 
 			// we need to use the same temporary user-space file across dbus client/server calls to coordinate
 			// the passing of screenshot images
-			string tmpdir = Environment.get_variable("XDG_RUNTIME_DIR") != null ? Environment.get_variable("XDG_RUNTIME_DIR") : Environment.get_variable("HOME");
+			string tmpdir = Environment.get_variable("XDG_RUNTIME_DIR") ?? Environment.get_variable("HOME");
 			tempfile_path = GLib.Path.build_path(GLib.Path.DIR_SEPARATOR_S, tmpdir, ".budgiescreenshot_tempfile");
 		}
 

--- a/src/daemon/screenshot.vala
+++ b/src/daemon/screenshot.vala
@@ -66,7 +66,7 @@ namespace BudgieScr {
 
 			// we need to use the same temporary user-space file across dbus client/server calls to coordinate
 			// the passing of screenshot images
-			string tmpdir = Environment.get_variable("XDG_RUNTIME_DIR") != null ? Environment.get_variable("XDG_RUNTIME_DIR") : Environment.get_variable("$HOME");
+			string tmpdir = Environment.get_variable("XDG_RUNTIME_DIR") != null ? Environment.get_variable("XDG_RUNTIME_DIR") : Environment.get_variable("HOME");
 			tempfile_path = GLib.Path.build_path(GLib.Path.DIR_SEPARATOR_S, tmpdir, ".budgiescreenshot_tempfile");
 		}
 

--- a/src/daemon/screenshot.vala
+++ b/src/daemon/screenshot.vala
@@ -64,12 +64,10 @@ namespace BudgieScr {
 				showtooltips = screenshot_settings.get_boolean("showtooltips");
 			});
 
-			// we need to use the same temporary file across instances
-			// so use the logged in user to differentiate in multiuser
-			// scenarios
-			string username = Environment.get_user_name();
-			string tmpdir = Environment.get_tmp_dir();
-			tempfile_path = GLib.Path.build_path(GLib.Path.DIR_SEPARATOR_S, tmpdir, username + "_budgiescreenshot_tempfile");
+			// we need to use the same temporary user-space file across dbus client/server calls to coordinate
+			// the passing of screenshot images
+			string tmpdir = Environment.get_variable("XDG_RUNTIME_DIR") != null ? Environment.get_variable("XDG_RUNTIME_DIR") : Environment.get_variable("$HOME");
+			tempfile_path = GLib.Path.build_path(GLib.Path.DIR_SEPARATOR_S, tmpdir, ".budgiescreenshot_tempfile");
 		}
 
 		private void fill_buttonpos() {

--- a/src/lib/notification.vala
+++ b/src/lib/notification.vala
@@ -115,27 +115,15 @@
 				category = variant.get_string();
 			}
 
-			// Try to set the application ID and app info
+			// Set the application ID and app info
 			if ((variant = hints.lookup("desktop-entry")) != null && variant.is_of_type(VariantType.STRING)) {
 				app_id = variant.get_string();
 				app_id.replace(".desktop", "");
 				app_info = new DesktopAppInfo("%s.desktop".printf(app_id));
+
+				if (app_info != null) app_name = app_info.get_string("Name") ?? app_name;
 			}
 
-			// Because following specs is a lost art, sometimes the desktop-entry
-			// value does not correspond to the desktop file. So, try to best-guess
-			// the desktop id instead.
-			if (app_info == null) {
-				app_id = app_name.replace(" ", "-").down();
-				app_info = new DesktopAppInfo("%s.desktop".printf(app_id));
-			}
-
-			// Make sure we have the best app name
-			if (app_info != null) {
-				app_name = app_info.get_string("Name") ?? app_name;
-			}
-
-			// Try to get the application's image
 			app_image = get_appinfo_image(Gtk.IconSize.DND, app_id.down());
 
 			bool image_found = false;
@@ -267,13 +255,9 @@
 
 		private Gtk.Image? get_appinfo_image(Gtk.IconSize size, string? fallback) {
 			if (app_info == null) {
-				var theme = Gtk.IconTheme.get_default();
-
-				if (!theme.has_icon(fallback)) {
-					return null;
-				}
-
-				return new Gtk.Image.from_icon_name(fallback, size);
+				var fallback_image = new Gtk.Image.from_icon_name(fallback, size);
+				var invalid_image = (fallback_image == null) || (fallback_image.icon_name == null) || (fallback_image.icon_name == "image-missing") || (fallback_image.icon_name == "");
+				return invalid_image ? null : fallback_image;
 			}
 
 			var app_icon_name = app_info.get_string("Icon"); // Use the Icon from the respective DesktopAppInfo or fallback to generic applications-internet
@@ -288,4 +272,4 @@
 			return null;
 		}
 	}
-}
+ }

--- a/src/lib/notification.vala
+++ b/src/lib/notification.vala
@@ -115,15 +115,27 @@
 				category = variant.get_string();
 			}
 
-			// Set the application ID and app info
+			// Try to set the application ID and app info
 			if ((variant = hints.lookup("desktop-entry")) != null && variant.is_of_type(VariantType.STRING)) {
 				app_id = variant.get_string();
 				app_id.replace(".desktop", "");
 				app_info = new DesktopAppInfo("%s.desktop".printf(app_id));
-
-				if (app_info != null) app_name = app_info.get_string("Name") ?? app_name;
 			}
 
+			// Because following specs is a lost art, sometimes the desktop-entry
+			// value does not correspond to the desktop file. So, try to best-guess
+			// the desktop id instead.
+			if (app_info == null) {
+				app_id = app_name.replace(" ", "-").down();
+				app_info = new DesktopAppInfo("%s.desktop".printf(app_id));
+			}
+
+			// Make sure we have the best app name
+			if (app_info != null) {
+				app_name = app_info.get_string("Name") ?? app_name;
+			}
+
+			// Try to get the application's image
 			app_image = get_appinfo_image(Gtk.IconSize.DND, app_id.down());
 
 			bool image_found = false;
@@ -255,9 +267,13 @@
 
 		private Gtk.Image? get_appinfo_image(Gtk.IconSize size, string? fallback) {
 			if (app_info == null) {
-				var fallback_image = new Gtk.Image.from_icon_name(fallback, size);
-				var invalid_image = (fallback_image == null) || (fallback_image.icon_name == null) || (fallback_image.icon_name == "image-missing") || (fallback_image.icon_name == "");
-				return invalid_image ? null : fallback_image;
+				var theme = Gtk.IconTheme.get_default();
+
+				if (!theme.has_icon(fallback)) {
+					return null;
+				}
+
+				return new Gtk.Image.from_icon_name(fallback, size);
 			}
 
 			var app_icon_name = app_info.get_string("Icon"); // Use the Icon from the respective DesktopAppInfo or fallback to generic applications-internet
@@ -272,4 +288,4 @@
 			return null;
 		}
 	}
- }
+}


### PR DESCRIPTION
## Description
Screenshot uses a temporary folder path to pass image data between the client and server dbus elements.

This PR ensures this temporary path is a user-space path rather than a system defined path.


### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
