### PR TITLE
Use user-space variables to pass temporary screenshot data

### DIFF
--- a/src/daemon/screenshot.vala
+++ b/src/daemon/screenshot.vala
@@ -64,12 +64,10 @@ namespace BudgieScr {
 				showtooltips = screenshot_settings.get_boolean("showtooltips");
 			});
 
-			// we need to use the same temporary file across instances
-			// so use the logged in user to differentiate in multiuser
-			// scenarios
-			string username = Environment.get_user_name();
-			string tmpdir = Environment.get_tmp_dir();
-			tempfile_path = GLib.Path.build_path(GLib.Path.DIR_SEPARATOR_S, tmpdir, username + "_budgiescreenshot_tempfile");
+			// we need to use the same temporary user-space file across dbus client/server calls to coordinate
+			// the passing of screenshot images
+			string tmpdir = Environment.get_variable("XDG_RUNTIME_DIR") ?? Environment.get_variable("HOME");
+			tempfile_path = GLib.Path.build_path(GLib.Path.DIR_SEPARATOR_S, tmpdir, ".budgiescreenshot_tempfile");
 		}
 
 		private void fill_buttonpos() {


### PR DESCRIPTION
## Description
Screenshot uses a temporary folder path to save image data between the client and server dbus elements.

This PR ensures a user-space location is used rather than a system location.


### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
