### PR TITLE
Fix heap buffer overflow in UsageMonitor

### DIFF
--- a/src/raven/widgets/usage-monitor/usage_monitor.vala
+++ b/src/raven/widgets/usage-monitor/usage_monitor.vala
@@ -214,7 +214,7 @@ public class UsageMonitorRavenWidget : Budgie.RavenWidget {
 				string label = "";
 				ulong value = -1;
 
-				line.scanf("%s %lu", label, &value);
+				line.scanf("%ms %lu", &label, &value);
 
 				if (label == "MemTotal:") {
 					contents.mem_total = value;


### PR DESCRIPTION
## Description

The `%ms` format specifier, when passed to POSIX scanf, allocates the necessary space for the value that it reads into a char**.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
