### PR TITLE
sendto: Use stateless XDG autostart directory if stateless is set

### DIFF
--- a/src/dialogs/sendto/meson.build
+++ b/src/dialogs/sendto/meson.build
@@ -36,7 +36,7 @@ executable(
 
 install_data(
     'org.buddiesofbudgie.sendto-daemon.desktop',
-    install_dir: join_paths(confdir, 'xdg', 'autostart')
+    install_dir: xdg_appdir
 )
 
 install_data(


### PR DESCRIPTION
## Description

Install the sendto autostart file to the correct stateless directory if statelessness has been enabled.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
