### PR TITLE
Switch to Fedora rawhide for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,8 @@ jobs:
             meson \
             sassc \
             zenity
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Build Budgie Desktop
         run: |
-          meson setup build
+          meson setup build -Dci=true
           meson compile -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,10 @@ jobs:
             meson \
             sassc \
             zenity
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Build Budgie Desktop
         run: |
-          meson setup build -Dci=true
+          meson build -Dci=true
           meson compile -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,43 @@ on:
       - main
       - v10.9.x
 jobs:
-  ubuntu:
-    runs-on: ubuntu-22.04
+  fedora:
+    runs-on: ubuntu-latest
+    container: "registry.fedoraproject.org/fedora:rawhide"
     steps:
-      - uses: actions/checkout@v1
-      - run: sudo add-apt-repository ppa:xubuntu-dev/experimental
-      - run: sudo apt update
-      - run: sudo apt remove libunwind-14-dev
-      - run: sudo apt install meson ninja-build zenity gnome-screensaver gnome-settings-daemon-dev gtk-doc-tools intltool libaccountsservice-dev libasound2-dev libcanberra-dev libcanberra-gtk3-dev libgee-0.8-dev libgnome-bluetooth-dev libgnome-desktop-3-dev libgnome-menu-3-dev libgtk-3-dev libibus-1.0-dev libmutter-10-dev libpeas-dev libpolkit-agent-1-dev libpulse-dev libupower-glib-dev libwnck-3-dev sassc uuid-dev valac libgstreamer1.0-dev libgee-0.8-dev libxfce4windowing-0-dev
-      - run: meson build -Duse-old-zenity=true -Dwith-gnome-screensaver=true
-      - run: meson compile -C build
+      - name: Install prerequisites
+        run: |
+          dnf install --assumeyes install
+            'pkgconfig(accountsservice)' \
+            'pkgconfig(alsa)' \
+            'pkgconfig(gee-0.8)' \
+            'pkgconfig(gnome-desktop-3.0)' \
+            'pkgconfig(gstreamer-1.0)' \
+            'pkgconfig(ibus-1.0)' \
+            'pkgconfig(libcanberra)' \
+            'pkgconfig(libnotify)' \
+            'pkgconfig(libpeas-1.0)' \
+            'pkgconfig(libpulse)' \
+            'pkgconfig(libwnck-3.0)' \
+            'pkgconfig(libxfce4windowing-0)' \
+            'pkgconfig(polkit-agent-1)' \
+            'pkgconfig(upower-glib)' \
+            'pkgconfig(uuid)' \
+            'pkgconfig(vapigen)' \
+            budgie-desktop-view \
+            budgie-screensaver \
+            desktop-file-utils \
+            gcc \
+            gettext \
+            git-core \
+            gtk-doc \
+            intltool \
+            magpie-devel \
+            meson \
+            sassc \
+            zenity
+      - uses: actions/checkout@v4
+      - name: Build Budgie Desktop
+        run: |
+          meson setup build
+          meson compile -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
             desktop-file-utils \
             gcc \
             gettext \
-            git-core \
+            git \
             gtk-doc \
             intltool \
             magpie-devel \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
             meson \
             sassc \
             zenity
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v1
       - name: Build Budgie Desktop
         run: |
           meson setup build -Dci=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          dnf install --assumeyes install \
+          dnf install --assumeyes \
             'pkgconfig(accountsservice)' \
             'pkgconfig(alsa)' \
             'pkgconfig(gee-0.8)' \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
             'pkgconfig(alsa)' \
             'pkgconfig(gee-0.8)' \
             'pkgconfig(gnome-desktop-3.0)' \
+            'pkgconfig(gnome-settings-daemon)' \
             'pkgconfig(gstreamer-1.0)' \
             'pkgconfig(ibus-1.0)' \
             'pkgconfig(libcanberra)' \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
             sassc \
             zenity
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - name: Build Budgie Desktop
         run: |
           meson setup build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          dnf install --assumeyes install
+          dnf install --assumeyes install \
             'pkgconfig(accountsservice)' \
             'pkgconfig(alsa)' \
             'pkgconfig(gee-0.8)' \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,9 +45,7 @@ jobs:
             meson \
             sassc \
             zenity
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
+      - uses: actions/checkout@v1
       - name: Build Budgie Desktop
         run: |
           meson setup build

--- a/meson.build
+++ b/meson.build
@@ -70,7 +70,8 @@ cdata = configuration_data()
 # Inspired by https://github.com/GNOME/recipes/blob/master/meson.build
 package_version = meson.project_version()
 
-if fs.exists('.git')
+ci = get_option('ci')
+if fs.exists('.git') and ci == false
     git = find_program('git')
     git_version = run_command('git', ['rev-parse', 'HEAD'], check: true)
     package_version += ' (git-'+git_version.stdout().strip()+')'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
+option('ci', type: 'boolean', value: false, description: 'Continuous Integration flag (internal use only)')
 option('use-old-zenity', type: 'boolean', value: false, description: 'Use old zenity CLI API for out-of-process dialog handling')
 option('with-bluetooth', type: 'boolean', value: true, description: 'Enable Bluetooth (Vala option)')
 option('with-gnome-screensaver', type: 'boolean', value: false, description: 'Build using gnome-screensaver as a dependency')


### PR DESCRIPTION
1. ubuntu CI failing due to too old of a upower. When new LTS is out we can add it back.
2. rawhide will help to identify breaking changes due to new toolchains.
3. actually get CI again.