### PR TITLE
Use Enum DOWN instead of LEFT to scroll in a left-wards direction

### DIFF
--- a/src/panel/applets/workspaces/WorkspacesApplet.vala
+++ b/src/panel/applets/workspaces/WorkspacesApplet.vala
@@ -207,7 +207,7 @@ namespace Workspaces {
 
 				unowned libxfce4windowing.Workspace current = workspace_group.get_active_workspace();
 				unowned libxfce4windowing.Workspace? next = current.get_neighbor(
-					(down) ? libxfce4windowing.Direction.RIGHT : libxfce4windowing.Direction.LEFT
+					(down) ? libxfce4windowing.Direction.RIGHT : libxfce4windowing.Direction.DOWN
 				);
 
 				if (next != null) {


### PR DESCRIPTION
…oses #541)

## Description
Use Enum DOWN instead of LEFT to scroll in a left-wards direction

Closes #541

This is definitely odd.  Looking at libxfce4windowing it does appear that their enum for motion direction is mapped correctly to wnck's values and our vapi is mapped to libxfce4windowing correctly.

So why using DOWN rather than LEFT works feels just wrong ... but works.  Just feels like there is a bug somewhere but not sure where.


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
