### PR TITLE
daemon/notifications: Fix default notification action being performed when close button is clicked

### DIFF
--- a/src/daemon/notifications/popup.vala
+++ b/src/daemon/notifications/popup.vala
@@ -85,9 +85,10 @@ namespace Budgie.Notifications {
 			this.add(revealer);
 
 			// Hook up the close button
-			close_button.clicked.connect(() => {
+			close_button.button_release_event.connect(() => {
 				this.Closed(NotificationCloseReason.DISMISSED);
 				this.dismiss();
+				return Gdk.EVENT_STOP;
 			});
 		}
 


### PR DESCRIPTION
## Description

Fixes the default notification action being done when the close button is clicked.

Fixes https://github.com/getsolus/packages/issues/990

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
