### PR TITLE
Disable C compiler warnings entirely

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,10 +13,9 @@ project(
 )
 
 # Vala generates bad C code and missing these on gcc 14 will cause FTBFS
-am_cflags = [
-    '-Wno-incompatible-pointer-types',
-    '-Wno-implicit-function-declaration',
-]
+# Additionally, Meson 1.4 unhides warnings from valac-generated C code,
+# which causes unreadable logspam. Reenables prior behavior.
+am_cflags = ['-w']
 add_global_arguments(am_cflags, language: 'c')
 
 budgie_screensaver  = find_program('budgie-screensaver', required: false)

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,11 @@ project(
 # Vala generates bad C code and missing these on gcc 14 will cause FTBFS
 # Additionally, Meson 1.4 unhides warnings from valac-generated C code,
 # which causes unreadable logspam. Reenables prior behavior.
-am_cflags = ['-w']
+am_cflags = [
+    '-w',
+    '-Wno-incompatible-pointer-types',
+    '-Wno-implicit-function-declaration',
+]
 add_global_arguments(am_cflags, language: 'c')
 
 budgie_screensaver  = find_program('budgie-screensaver', required: false)


### PR DESCRIPTION
## Description

In Meson 1.4.0, warnings for Vala-transpiled C code were unhidden, which causes the Budgie build to turn into unreadable logspam due to the absolutely abysmal C code generated by Vala. This PR restores the prior behavior by disabling all warnings for C code.

Let it be known that I didn't want to have to do this and would have fixed the code myself. *If I could have.*

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
