### PR TITLE
windowing: Set a new last active window when the last active window is closed

### DIFF
--- a/src/windowing/window_group.vala
+++ b/src/windowing/window_group.vala
@@ -105,7 +105,10 @@ namespace Budgie.Windowing {
 			}
 
 			if (last_active_window == window) {
-				last_active_window = null;
+				// Set the last window before this one as the last active window.
+				// We do this so there should always be a valid window to focus
+				// when tasklist buttons are clicked.
+				last_active_window = get_next_window(window, true);
 			}
 
 			window_removed(window);


### PR DESCRIPTION
## Description

Sets the previous active window in a group to another window when a window is closed. This prevents button focus and activation issues when a window in a group is closed.

Fixes https://github.com/BuddiesOfBudgie/budgie-desktop/issues/565

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
