### PR TITLE
Fix end session dialog blocking authentication dialog

### DIFF
--- a/src/daemon/endsession.vala
+++ b/src/daemon/endsession.vala
@@ -66,6 +66,7 @@ namespace Budgie {
 		void restart_clicked() {
 			Closed();
 			ConfirmedReboot();
+			hide();
 		}
 
 		[GtkCallback]
@@ -73,6 +74,7 @@ namespace Budgie {
 		void shutdown_clicked() {
 			Closed();
 			ConfirmedShutdown();
+			hide();
 		}
 
 		[DBus (visible=false)]


### PR DESCRIPTION
## Description
Fix the end session dialog blocking the authentication dialog when a password is required to shut down the computer.

The fix was to hide the shutdown dialog when the "Shutdown" button is clicked.

### Screenshot
![Snapshot_2024-05-18_15-22-47](https://github.com/BuddiesOfBudgie/budgie-desktop/assets/9561483/6bd80326-321a-4d35-bf06-39bf2373ffcc)



### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
