### PR TITLE
budgie-menu: Show terminal applications in the menu

### DIFF
--- a/src/appindexer/AppIndex.vala
+++ b/src/appindexer/AppIndex.vala
@@ -287,8 +287,7 @@ namespace Budgie {
 			// We have to make sure to add BCC panel items because they
 			// have NoDisplay set, so this would otherwise exclude them.
 			// Showing/hiding them is handled by the UI layer.
-			bool should_skip = (!app_info.should_show() && !is_control_center_panel) ||
-								(app_info.get_boolean("Terminal"));
+			bool should_skip = !app_info.should_show() && !is_control_center_panel;
 
 			if (should_skip) {
 				return;


### PR DESCRIPTION
## Description

Enables the showing of terminal applications in the Budgie Menu.

Fixes https://github.com/BuddiesOfBudgie/budgie-desktop/issues/554

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
