### PR TITLE
Don't show tabswitcher if window is empty

### DIFF
--- a/src/daemon/tabswitcher.vala
+++ b/src/daemon/tabswitcher.vala
@@ -256,7 +256,7 @@ namespace Budgie {
 			return pos1 < pos2 ? -1 : 1;
 		}
 
-		private uint get_visible_children() {
+		public uint get_visible_children() {
 			uint visible_children = 0;
 			foreach (var child in window_box.get_children()) {
 				var tab = child as TabSwitcherWidget;
@@ -456,6 +456,7 @@ namespace Budgie {
 			}
 
 			public void ShowSwitcher(bool backwards) throws DBusError, IOError {
+				if (switcher_window.get_visible_children() == 0) return;
 				this.add_mod_key_watcher();
 
 				switcher_window.move_switcher();


### PR DESCRIPTION
## Description

When pressing Alt-Tab with no active windows, the tabswitcher window still appears. No icons are displayed and the window title is either blank, or the last window selected via alt-tab. It appears this is due to the window being set to show on the keypress regardless of the number of active children.

This PR would address this by making the "get_visible_children" public so the DBus function can check if there are items in the tabswitcher window before showing the window. Since this function already takes into consideration the "Show all windows in tab switcher" setting in BDS, it ensures the tab switcher will still work correctly with this setting on or off.

Closes #578

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
