### PR TITLE
icon-tasklist: Fix some pinned launchers not properly updating when opened

### DIFF
--- a/src/panel/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/panel/applets/icon-tasklist/IconTasklistApplet.vala
@@ -427,9 +427,18 @@ public class IconTasklistApplet : Budgie.Applet {
 		if (button == null) { // Button might be pinned, try to get button from launcher instead
 			app_id = group.get_desktop_id();
 			button = buttons.get(app_id);
+
+			// Because the only way to get a desktop_id from an application on X11 is basically
+			// to just guess, the casing may not be correct, e.g. Nemo.desktop vs nemo.desktop.
+			// Try again to get the button, this time making the desktop_id all lowercase.
+			if (button == null) {
+				app_id = app_id.down();
+				button = buttons.get(app_id);
+			}
 		}
 
 		if (button == null) { // we don't manage this button
+			warning(@"an application ($(group.group_id)) was closed, but we couldn't find its button");
 			return;
 		}
 

--- a/src/panel/applets/icon-tasklist/widgets/IconButton.vala
+++ b/src/panel/applets/icon-tasklist/widgets/IconButton.vala
@@ -620,14 +620,14 @@ public class IconButton : Gtk.ToggleButton {
 	public void update() {
 		if (window_group != null && window_group.has_windows()) {
 			get_style_context().add_class("running");
-		} else {
+		} else if (window_group != null && !window_group.has_windows()) {
 			get_style_context().remove_class("running");
 
 			if (!pinned) return;
-			window_group = null;
 
 			var active_window = window_group?.get_active_window() ?? window_group?.get_last_active_window();
 			set_tooltip_text(app?.name ?? active_window?.get_name() ?? "");
+			window_group = null;
 		}
 
 		set_active(has_active_window);


### PR DESCRIPTION
## Description

In some cases, opening an application, closing it, and re-opening it again from a pinned launcher would fail to update the launcher button; it would just be stuck doing the waiting animation, despite the application and a window appearing. This is because on X11, you pretty much have to just guess at what the desktop ID is for an application. We do this using the application's name, which may not be in the correct letter casing. This leads to the tasklist searching for, e.g., Nemo.desktop when you really want nemo.desktop.

To get around this, first check using the same ID we did before. If that doesn't work, try again with converting the guessed ID to lowercase.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
