### PR TITLE
Let peas chew on v2.0 for python based plugins

### DIFF
--- a/src/panel/plugin_manager.vala
+++ b/src/panel/plugin_manager.vala
@@ -34,7 +34,7 @@ namespace Budgie {
 				var repo = GI.Repository.get_default();
 				repo.require("Peas", "1.0", 0);
 				repo.require("PeasGtk", "1.0", 0);
-				repo.require("Budgie", "1.0", 0);
+				repo.require("Budgie", "2.0", 0);
 			} catch (Error e) {
 				message("Error loading typelibs: %s", e.message);
 			}


### PR DESCRIPTION
## Description
For wayland we need to ensure python based plugins are v2.0


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
