### PR TITLE
Add missing dependency to 'trash' applet meson.build

### DIFF
--- a/src/panel/applets/trash/meson.build
+++ b/src/panel/applets/trash/meson.build
@@ -34,6 +34,7 @@ applet_trash_deps = [
     dep_gtk3,
     dep_notify,
     dep_peas,
+    link_libpanelenum,
     link_libpanelplugin,
 ]
 


### PR DESCRIPTION
## Description
link_libpanelenum is not currently listed in applet_trash_deps. Although this builds just fine on systems using meson with ninja, this will result in build failure on systems that use meson with samurai, outputting the following error message:

```
In file included from .. /src/panel/applets/trash/trash_plugin.h:14,
		from /src/panel/applets/trash/trash_plugin.h:15:
../src/plugin/panel/plugin.h:16:10: fatal error: budgie-enums.h: no such file or directory 
```

This error can be especially problematic on distros like Alpine Linux which only ship samurai in the main repositories. Apparently, this is due to a difference in how ninja and samurai schedule build edges (see [Meson Issue #9937](https://github.com/mesonbuild/meson/issues/9937#issuecomment-1029293627) & [samurai differences from ninja](https://github.com/michaelforney/samurai?tab=readme-ov-file#differences-from-ninja)), which consequently requires dependencies to be specified more explicitly.

Therefore, this pull requests adds link_libpanelenum into applet_trash_deps, to ensure that Budgie can be built and compiled on any system.

Also, somewhat related to the pull request, I noticed that link_libpanelenum is not actually linked to libpanelenum. I refrained from modifying this in case there was a functional reason for it, but I'd happily create another pull request for it if there's none.


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
