### PR TITLE
Add a root menu for the desktop

### DIFF
--- a/src/bridges/labwc/menu.xml
+++ b/src/bridges/labwc/menu.xml
@@ -1,0 +1,10 @@
+<openbox_menu>
+	<menu id="root-menu">
+		<item label="Budgie Desktop Settings" original="Budgie Desktop Settings">
+			<action name="Execute" command="budgie-desktop-settings" />
+		</item>
+		<item label="System Settings" original="System Settings">
+			<action name="Execute" command="budgie-control-center" />
+		</item>
+	</menu>
+</openbox_menu>

--- a/src/bridges/labwc/meson.build
+++ b/src/bridges/labwc/meson.build
@@ -28,3 +28,8 @@ install_data(
     'environment',
     install_dir: join_paths(datadir, 'budgie-desktop')
 )
+
+install_data(
+    'menu.xml',
+    install_dir: join_paths(datadir, 'budgie-desktop')
+)


### PR DESCRIPTION
## Description
This PR adds a root menu where no desktop icons is used.

The bridge has been updated to copy the menu from the installed shared folder - or from the distro- equivalent if a distro wants their own custom folder.

Translations for the menu labels are handled as well on the startup of the bridge.

Note - the old menu code will be deleted in a separate PR in-coming via the osdkeys branch

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
