### PR TITLE
meson: Explicitly add gio-unix-2.0

### DIFF
--- a/src/windowing/meson.build
+++ b/src/windowing/meson.build
@@ -5,6 +5,7 @@ libwindowing_sources = [
 ]
 
 libwindowing_deps = [
+  dep_giounix,
   dep_xfce4windowing,
   dep_wnck,
 ]


### PR DESCRIPTION


## Description

This is another instance of #185. Since we are [using `DesktopAppInfo` directly](https://github.com/search?q=repo%3ABuddiesOfBudgie%2Fbudgie-desktop+DesktopAppInfo+path%3A%2F%5Esrc%5C%2Fwindowing%5C%2F%2F&type=code), let's add `gio-unix-2.0` explicitly.


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
