### PR TITLE
Switch session files, leave magpie session in the code for a future release

### DIFF
--- a/src/session/budgie-desktop-labwc.desktop.in.in
+++ b/src/session/budgie-desktop-labwc.desktop.in.in
@@ -1,8 +1,0 @@
-[Desktop Entry]
-_Name=Budgie Desktop (labwc)
-_Comment=This session logs you into the Budgie Desktop using labwc as the window manager
-Exec=@prefix@/bin/labwc -S /usr/bin/budgie-desktop
-TryExec=@prefix@/bin/labwc
-Icon=
-Type=Application
-DesktopNames=Budgie

--- a/src/session/budgie-desktop-magpie.desktop.in.in
+++ b/src/session/budgie-desktop-magpie.desktop.in.in
@@ -1,0 +1,8 @@
+[Desktop Entry]
+_Name=Budgie Desktop (magpie)
+_Comment=This session logs you into the Budgie Desktop using magpie as the window manager
+Exec=@prefix@/bin/magpie-wm -s /usr/bin/budgie-desktop
+TryExec=@prefix@/bin/magpie-wm
+Icon=
+Type=Application
+DesktopNames=Budgie

--- a/src/session/budgie-desktop.desktop.in.in
+++ b/src/session/budgie-desktop.desktop.in.in
@@ -1,8 +1,8 @@
 [Desktop Entry]
 _Name=Budgie Desktop
-_Comment=This session logs you into the Budgie Desktop
-Exec=@prefix@/bin/magpie-wm -s /usr/bin/budgie-desktop
-TryExec=@prefix@/bin/magpie-wm
+_Comment=This session logs you into the Budgie Desktop using labwc as the window manager
+Exec=@prefix@/bin/labwc -S /usr/bin/budgie-desktop
+TryExec=@prefix@/bin/labwc
 Icon=
 Type=Application
 DesktopNames=Budgie

--- a/src/session/meson.build
+++ b/src/session/meson.build
@@ -78,21 +78,21 @@ custom_target('desktop-file-waylandsession',
     install_dir : join_paths(datadir, 'wayland-sessions'),
 )
 
-# Configure the labwc wayland-session file
-waylandlabwcsession_conf = configure_file(
-    input: 'budgie-desktop-labwc.desktop.in.in',
-    output: 'budgie-desktop-labwc.desktop.in',
-    configuration: session_data,
-)
+# Configure the magpie wayland-session file
+#waylandmagpiesession_conf = configure_file(
+#    input: 'budgie-desktop-magpie.desktop.in.in',
+#    output: 'budgie-desktop-magpie.desktop.in',
+#    configuration: session_data,
+#)
 
 # Now merge the translations of the .desktop.in to a .desktop
-custom_target('desktop-file-waylandlabwcsession',
-    input : waylandlabwcsession_conf,
-    output : 'budgie-desktop-labwc.desktop',
-    command : [intltool, '--desktop-style', podir, '@INPUT@', '@OUTPUT@'],
-    install : true,
-    install_dir : join_paths(datadir, 'wayland-sessions'),
-)
+#custom_target('desktop-file-waylandmagpiesession',
+#    input : waylandmagpiesession_conf,
+#    output : 'budgie-desktop-magpie.desktop',
+#    command : [intltool, '--desktop-style', podir, '@INPUT@', '@OUTPUT@'],
+#    install : true,
+#    install_dir : join_paths(datadir, 'wayland-sessions'),
+#)
 
 # Merge + install nm-applet
 custom_target('desktop-file-nm-applet',


### PR DESCRIPTION
## Description
Switch the sessions to make labwc the default for the 10.10 release.

Leave the magpie session in the code, but commented out.  We can later reinstate this as a default as and when needed.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
