### PR TITLE
Add on-demand to the polkit window to ensure entry field is editable

### DIFF
--- a/src/dialogs/polkit/polkitdialog.vala
+++ b/src/dialogs/polkit/polkitdialog.vala
@@ -149,6 +149,7 @@ namespace Budgie {
 			GtkLayerShell.set_monitor(this, primary_monitor.get_gdk_monitor());
 			GtkLayerShell.set_anchor(this, GtkLayerShell.Edge.LEFT, false);
 			GtkLayerShell.set_anchor(this, GtkLayerShell.Edge.TOP, false);
+			GtkLayerShell.set_keyboard_mode(this, GtkLayerShell.KeyboardMode.ON_DEMAND);
 
 			key_release_event.connect(on_key_release);
 


### PR DESCRIPTION
## Description
This ensures the polkit window editable field is focused.

Note - it appears that wlroots based compositors need the user to run the following to allow polkit windows to have the permissions to actually execute what pkexec wants to run for xwayland apps.

    xhost + local:

Without the above in journalctl you see the following:

    Authorization required, but no authorization protocol specified

There maybe some other secret sauce here get the extant polkit code to-do this for the user, but I don't know what this wouldbe.


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
