### PR TITLE
fix: workspace applet wayland support

### DIFF
--- a/src/panel/applets/workspaces/WindowIcon.vala
+++ b/src/panel/applets/workspaces/WindowIcon.vala
@@ -11,19 +11,30 @@
 
 namespace Workspaces {
 	public const int WORKSPACE_ICON_SIZE = 16;
+	public const string FALLBACK_ICON_NAME = "image-missing";
 
 	public class WindowIcon : Gtk.Button {
-		private libxfce4windowing.Window window;
+		public libxfce4windowing.Window window { get; construct; }
 
-		public WindowIcon(libxfce4windowing.Window window) {
-			this.window = window;
-
+		construct {
 			this.set_relief(Gtk.ReliefStyle.NONE);
 			this.get_style_context().add_class("workspace-icon-button");
 			this.set_tooltip_text(window.get_name());
 
-			Gtk.Image icon = new Gtk.Image.from_gicon(window.get_gicon(), Gtk.IconSize.INVALID);
-			icon.set_pixel_size(WORKSPACE_ICON_SIZE);
+			Gtk.Image icon;
+
+			// When a window has just been created, its application
+			// may not be set yet, so default to a generic icon if
+			// there is no application. It will be set when the
+			// icon_changed signal is called.
+			if (this.window.application != null) {
+				unowned var pixbuf = window.get_icon(WORKSPACE_ICON_SIZE, get_scale_factor());
+				icon = new Gtk.Image.from_pixbuf(pixbuf);
+			} else {
+				icon = new Gtk.Image.from_icon_name(FALLBACK_ICON_NAME, Gtk.IconSize.INVALID);
+				icon.pixel_size = WORKSPACE_ICON_SIZE;
+			}
+
 			this.add(icon);
 			icon.show();
 
@@ -32,8 +43,10 @@ namespace Workspaces {
 			});
 
 			window.icon_changed.connect(() => {
-				icon.set_from_gicon(window.get_gicon(), Gtk.IconSize.INVALID);
+				unowned var pixbuf = window.get_icon(WORKSPACE_ICON_SIZE, get_scale_factor());
+				icon.set_from_pixbuf(pixbuf);
 				icon.queue_draw();
+				Gtk.drag_source_set_icon_pixbuf(this, pixbuf);
 			});
 
 			Gtk.drag_source_set(
@@ -43,13 +56,15 @@ namespace Workspaces {
 				Gdk.DragAction.MOVE
 			);
 
-			Gtk.drag_source_set_icon_gicon(this, window.get_gicon());
-
 			this.drag_begin.connect(on_drag_begin);
 			this.drag_end.connect(on_drag_end);
 			this.drag_data_get.connect(on_drag_data_get);
 
 			this.show_all();
+		}
+
+		public WindowIcon(libxfce4windowing.Window window) {
+			Object(window: window);
 		}
 
 		public override bool button_release_event(Gdk.EventButton event) {
@@ -72,22 +87,7 @@ namespace Workspaces {
 		}
 
 		public void on_drag_data_get(Gtk.Widget widget, Gdk.DragContext context, Gtk.SelectionData selection_data, uint target_type, uint time) {
-			ulong window_xid = (ulong)window.x11_get_xid();
-			uchar[] buf;
-			convert_ulong_to_bytes(window_xid, out buf);
-			selection_data.set(
-				selection_data.get_target(),
-				8,
-				buf
-			);
-		}
-
-		private void convert_ulong_to_bytes(ulong number, out uchar[] buffer) {
-			buffer = new uchar[sizeof(ulong)];
-			for (int i=0; i<sizeof(ulong); i++) {
-				buffer[i] = (uchar)(number & 0xFF);
-				number = number >> 8;
-			}
+			selection_data.set_text(string.joinv(",", window.get_class_ids()), -1);
 		}
 	}
 }

--- a/src/panel/applets/workspaces/WorkspaceItem.vala
+++ b/src/panel/applets/workspaces/WorkspaceItem.vala
@@ -11,7 +11,7 @@
 
 namespace Workspaces {
 	const Gtk.TargetEntry[] target_list = {
-		{ "application/x-wnck-window-id", 0, 0 }
+		{ "text/plain", 0, 0 }
 	};
 
 	public class WorkspaceItem : Gtk.EventBox {
@@ -174,12 +174,13 @@ namespace Workspaces {
 		private void on_drag_data_received(Gtk.Widget widget, Gdk.DragContext context, int x, int y, Gtk.SelectionData selection_data, uint target_type, uint time) {
 			bool dnd_success = false;
 
-			ulong* data = (ulong*)selection_data.get_data();
+			string? data = selection_data.get_text();
 
 			if (data != null) {
 				try {
 					foreach (libxfce4windowing.Window window in WorkspacesApplet.xfce_screen.get_windows()) {
-						if (window.x11_get_xid() == *data) {
+						string all_class_names = string.joinv(",", window.get_class_ids());
+						if (all_class_names == data) {
 							window.move_to_workspace(this.workspace);
 							dnd_success = true;
 							break;
@@ -193,7 +194,7 @@ namespace Workspaces {
 			Gtk.drag_finish(context, dnd_success, true, time);
 		}
 
-		public void update_windows(List<weak libxfce4windowing.Window> window_list) {
+		public void update_windows(List<libxfce4windowing.Window> window_list) {
 			int num_columns = (real_alloc.width - 4) / 20;
 			int num_rows = (real_alloc.height - 4) / 20;
 

--- a/src/panel/applets/workspaces/WorkspacesApplet.vala
+++ b/src/panel/applets/workspaces/WorkspacesApplet.vala
@@ -115,6 +115,14 @@ namespace Workspaces {
 			add_button.get_style_context().add_class("workspace-add-button");
 			add_button.valign = Gtk.Align.CENTER;
 			add_button.halign = Gtk.Align.CENTER;
+
+			if (!(libxfce4windowing.WorkspaceGroupCapabilities.CREATE_WORKSPACE in workspace_group.get_capabilities())) {
+				add_button.sensitive = false;
+				add_button.set_tooltip_text(_("Not able to create new workspaces"));
+			} else {
+				add_button.set_tooltip_text(_("Create a new workspace"));
+			}
+
 			add_button_revealer.add(add_button);
 			main_layout.pack_start(add_button_revealer, false, false, 0);
 
@@ -209,6 +217,18 @@ namespace Workspaces {
 				}
 
 				return Gdk.EVENT_STOP;
+			});
+
+			workspace_group.capabilities_changed.connect((changed_mask, new_capabilities) => {
+				if (libxfce4windowing.WorkspaceGroupCapabilities.CREATE_WORKSPACE in changed_mask) {
+					if (!(libxfce4windowing.WorkspaceGroupCapabilities.CREATE_WORKSPACE in new_capabilities)) {
+						add_button.sensitive = false;
+						add_button.set_tooltip_text(_("Not able to create new workspaces"));
+					} else {
+						add_button.sensitive = true;
+						add_button.set_tooltip_text(_("Create a new workspace"));
+					}
+				}
 			});
 		}
 


### PR DESCRIPTION
## Description

This PR does a few things for the workspace applet:

- Removes any reference to BudgieWM, since that is no longer used.
- Removes any remaining Wnck/xid code.
- Fixes a crash when a window is opened.
- Makes the add workspace button unlickable if a new workspace cannot be added.

The only other outstanding issue that I know of so far is that hovering the mouse over the add workspace button when it's set to only show on hover causes the revealer to keep opening and closing in rapid succession for as long as the mouse is there.

This should fix #470. If any further refinements are needed, they can be done later in separate PRs.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
