### PR TITLE
Test to see if the gammastep local folder actually exists before creating it

### DIFF
--- a/src/daemon/nightlight.vala
+++ b/src/daemon/nightlight.vala
@@ -74,11 +74,16 @@ namespace Budgie {
 
 			if (default_config_path != null && default_config_path != local_config_path) {
 				try {
-					// Copy the default configuration file to the local configuration file location
+					// Create the local folder to hold our configuration file
 					File dir = File.new_for_path(Path.get_dirname(local_config_path));
 					if (!dir.query_exists()) {
 						dir.make_directory_with_parents(null);
 					}
+				} catch (Error e) {
+					warning("Failed to create local folder: %s\n", e.message);
+				}
+				try {
+					// Copy the default configuration file to the local configuration file location
 					File default_config_file = File.new_for_path(default_config_path);
 					File local_config_file = File.new_for_path(local_config_path);
 					default_config_file.copy(local_config_file, FileCopyFlags.NONE, null, null);

--- a/src/daemon/nightlight.vala
+++ b/src/daemon/nightlight.vala
@@ -76,12 +76,13 @@ namespace Budgie {
 				try {
 					// Create the local folder to hold our configuration file
 					File dir = File.new_for_path(Path.get_dirname(local_config_path));
-					if (!dir.query_exists()) {
-						dir.make_directory_with_parents(null);
-					}
+					dir.make_directory_with_parents(null);
+				} catch (IOError.EXISTS exist_error) {
+					/* It's not an error to worry about if the folder exists */
 				} catch (Error e) {
 					warning("Failed to create local folder: %s\n", e.message);
 				}
+
 				try {
 					// Copy the default configuration file to the local configuration file location
 					File default_config_file = File.new_for_path(default_config_path);
@@ -96,6 +97,7 @@ namespace Budgie {
 		private void update_gammastep_config() {
 			try {
 				// Load the configuration file
+				ensure_local_config_exists();
 				KeyFile key_file = new KeyFile();
 				key_file.load_from_file(local_config_path, KeyFileFlags.NONE);
 

--- a/src/daemon/nightlight.vala
+++ b/src/daemon/nightlight.vala
@@ -76,7 +76,9 @@ namespace Budgie {
 				try {
 					// Copy the default configuration file to the local configuration file location
 					File dir = File.new_for_path(Path.get_dirname(local_config_path));
-					dir.make_directory_with_parents(null);
+					if (!dir.query_exists()) {
+						dir.make_directory_with_parents(null);
+					}
 					File default_config_file = File.new_for_path(default_config_path);
 					File local_config_file = File.new_for_path(local_config_path);
 					default_config_file.copy(local_config_file, FileCopyFlags.NONE, null, null);


### PR DESCRIPTION
## Description
nightlight copies a default config from a system location to a local folder.

Normally this is ok on a first login.  

However, this local folder may already exist if gammastep is in use from another DE.

So lets test to see if the folder actually exists before trying to create the gammastep folder... thus allowing the budgie config to be successfully copied into the gammastep folder

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
