### PR TITLE
Cleanup X11 compiler usage

### DIFF
--- a/src/panel/applets/icon-tasklist/meson.build
+++ b/src/panel/applets/icon-tasklist/meson.build
@@ -40,9 +40,7 @@ applet_icontasklist_deps = [
     dep_giounix,
     dep_gtk3,
     dep_peas,
-    dep_wnck,
     dep_xfce4windowing,
-    dep_gdkx11,
     link_libwindowing,
     link_libappsys,
     link_libpanelplugin,
@@ -60,9 +58,7 @@ shared_library(
     vala_args: [
         '--pkg', 'libpeas-1.0',
         '--pkg', 'gtk+-3.0',
-        '--pkg', 'gdk-x11-3.0',
         '--pkg', 'gio-unix-2.0',
-        '--pkg', 'libwnck-3.0',
         '--pkg', 'libxfce4windowing-0',
         '--vapidir', dir_libappsys,
         '--vapidir', dir_libwindowing,
@@ -70,9 +66,6 @@ shared_library(
         # Make gresource work
         '--target-glib=2.38',
         '--gresources=' + gresource,
-    ],
-    c_args: [
-        '-DWNCK_I_KNOW_THIS_IS_UNSTABLE',
     ],
     install: true,
     install_dir: applet_icontasklist_dir,

--- a/src/panel/meson.build
+++ b/src/panel/meson.build
@@ -73,7 +73,6 @@ budgie_panel_vala_args = [
         '--pkg', 'gvc-1.0',
         '--pkg', 'libpeas-1.0',
         '--pkg', 'gtk+-3.0',
-        '--pkg', 'gdk-x11-3.0',
         '--pkg', 'gio-unix-2.0',
         '--pkg', 'gtk-layer-shell-0',
         '--pkg', 'libxfce4windowing-0',
@@ -82,15 +81,10 @@ budgie_panel_vala_args = [
         '--gresources=' + gresource,
 ]
 
-budgie_panel_c_args = [
-    '-DWNCK_I_KNOW_THIS_IS_UNSTABLE'
-]
-
 executable(
     'budgie-panel', panel_sources,
     dependencies: panel_deps,
     vala_args: budgie_panel_vala_args,
-    c_args: budgie_panel_c_args,
     install: true,
 )
 

--- a/src/raven/meson.build
+++ b/src/raven/meson.build
@@ -68,7 +68,6 @@ libraven = shared_library(
         '--pkg', 'gvc-1.0',
         '--pkg', 'libpeas-1.0',
         '--pkg', 'gtk+-3.0',
-        '--pkg', 'gdk-x11-3.0',
         '--pkg', 'gio-unix-2.0',
         '--pkg', 'gtk-layer-shell-0',
         '--pkg', 'libxfce4windowing-0',

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -296,13 +296,8 @@ namespace Budgie {
 				return;
 			}
 			if (!has_toplevel_focus) {
-				/* X11 specific. */
 				Gdk.Display? display = screen.get_display();
-				if (display is Gdk.X11.Display) {
-					window.focus(((Gdk.X11.Display) display).get_user_time());
-				} else {
-					window.focus(Gtk.get_current_event_time());
-				}
+				window.focus(Gtk.get_current_event_time());
 			}
 		}
 

--- a/src/windowing/meson.build
+++ b/src/windowing/meson.build
@@ -7,20 +7,15 @@ libwindowing_sources = [
 libwindowing_deps = [
   dep_giounix,
   dep_xfce4windowing,
-  dep_wnck,
 ]
 
 libwindowing = static_library(
   'windowing',
   libwindowing_sources,
   dependencies: libwindowing_deps,
-  c_args: [
-    '-DWNCK_I_KNOW_THIS_IS_UNSTABLE',
-  ],
   vala_args: [
     '--pkg', 'gio-unix-2.0',
     '--pkg', 'gtk+-3.0',
-    '--pkg', 'gdk-x11-3.0',
     '--pkg', 'libxfce4windowing-0',
     '--vapidir', join_paths(meson.source_root(), 'vapi'),
   ],


### PR DESCRIPTION
## Description
This removes various X11 specific compilation issues - mostly library usage.

Quick look, AppSys and tasklist applet are the key remaining areas still requiring X11 based code.

Have had a look around and I don't see any obvious issues by removing this stuff.  

Worth a second/third pair of eyes 

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
