### PR TITLE
Add override for overlay-key to prevent crash with mutter-common v48-rc

### DIFF
--- a/src/wm/20_solus-project.budgie.wm.gschema.override
+++ b/src/wm/20_solus-project.budgie.wm.gschema.override
@@ -1,6 +1,7 @@
 [org.gnome.mutter:Budgie]
 edge-tiling = true
 attach-modal-dialogs = true
+overlay-key = "Super_L"
 
 [org.gnome.desktop.background:Budgie]
 picture-uri = 'file:///usr/share/backgrounds/budgie/default.jpg'


### PR DESCRIPTION
## Description
Use  the pre- overlay-key value to prevent magpie window manager crash when mutter-common v48-rc is installed


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
