### PR TITLE
Bump the plugin version since the API/ABI has been updated

### DIFF
--- a/src/panel/plugin_manager.vala
+++ b/src/panel/plugin_manager.vala
@@ -34,7 +34,7 @@ namespace Budgie {
 				var repo = GI.Repository.get_default();
 				repo.require("Peas", "1.0", 0);
 				repo.require("PeasGtk", "1.0", 0);
-				repo.require("Budgie", "1.0", 0);
+				repo.require("Budgie", "2.0", 0);
 			} catch (Error e) {
 				message("Error loading typelibs: %s", e.message);
 			}


### PR DESCRIPTION
## Description
This is required to prevent old plugins crashing the panel due to API/ABI changes


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
