### PR TITLE
use budgie friendly folder for our labwc config file

### DIFF
--- a/src/bridges/labwc/labwc_bridge.py
+++ b/src/bridges/labwc/labwc_bridge.py
@@ -59,7 +59,7 @@ class Bridge:
             mainloop=quit()
 
     def user_config(self, config_file="rc.xml"):
-        return os.path.join(GLib.get_user_config_dir(), "labwc", config_file)
+        return os.path.join(GLib.get_user_config_dir(), "budgie-desktop", "labwc", config_file)
 
     # writes the labwc rc.xml file back
     def write_config(self):
@@ -134,7 +134,7 @@ class Bridge:
             self.log.warning(e)
             return
 
-        self.translate_menu_labels(path)
+        self.translate_menu_labels(search_path[0])
 
         path,search_path = self.search_for_config("rc.xml")
         if path == None:


### PR DESCRIPTION
## Description

as per xfce4-session they use a config file specific to xfce4 i.e. ~/.config/xfce4/labwc

Lets be labwc friendly and similarly use a DE specific folder i.e. ~/.config/budgie-desktop/labwc

At the same time fix a crash on first startup where we were trying to translate the system menu.xml file (causing a permissions failure) rather than the freshly copied local menu.xml which can be written to.


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
