### PR TITLE
Use a static shared-library for the windowing capability to ensure chroot based packages have something to link against

### DIFF
--- a/src/windowing/meson.build
+++ b/src/windowing/meson.build
@@ -9,24 +9,35 @@ libwindowing_deps = [
   dep_xfce4windowing,
 ]
 
-libwindowing = static_library(
-  'windowing',
+libwindowing = shared_library(
+  'budgie-windowing',
   libwindowing_sources,
   dependencies: libwindowing_deps,
   vala_args: [
     '--pkg', 'gio-unix-2.0',
     '--pkg', 'gtk+-3.0',
     '--pkg', 'libxfce4windowing-0',
-    '--vapidir', join_paths(meson.source_root(), 'vapi'),
+    '--vapidir', join_paths(meson.project_source_root(), 'vapi'),
   ],
+  version: '0.0.0',
+  install: true,
+)
+
+# Allow building against libbudgie-windowing
+pkgconfig.generate(
+    name: 'Budgie Windowing',
+    description: 'Budgie Windowing Library',
+    version: '1',
+    filebase: 'budgie-windowing-1.0',
+    libraries: ['-L${libdir}', '-lbudgie-windowing'],
+    requires: ['gtk+-3.0 >= 3.24.0']
 )
 
 link_libwindowing = declare_dependency(
   link_with: libwindowing,
-  include_directories: [
-    include_directories('.'),
-  ],
-)
+  dependencies: libwindowing_deps,
+  include_directories: include_directories('.'),
+).as_static()
 
 # Expose the current directory so that we can use vapidir
 dir_libwindowing = meson.current_build_dir()


### PR DESCRIPTION
## Description
Similarly for other code library usage (plugins, themes, panels etc), this defines a shared library for the windowing codebase to allow Debian (and possibly others) something to link against. 

The effect of this change is to have a functional icon-tasklist with new windows appearing as icons.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
