### PR TITLE
Partial revert of #690

### DIFF
--- a/src/bridges/labwc/labwc_bridge.py
+++ b/src/bridges/labwc/labwc_bridge.py
@@ -59,7 +59,7 @@ class Bridge:
             mainloop=quit()
 
     def user_config(self, config_file="rc.xml"):
-        return os.path.join(GLib.get_user_config_dir(), "budgie-desktop", "labwc", config_file)
+        return os.path.join(GLib.get_user_config_dir(), "labwc", config_file)
 
     # writes the labwc rc.xml file back
     def write_config(self):


### PR DESCRIPTION
## Description
This removes the budgie-desktop part of where the labwc config file was saved to in #690.

My bad - I forgot to test with removing the original ~/.config/labwc

You'll note that when you do this, labwc doesnt actually use ~/.config/budgie-desktop/labwc

Changing /usr/share/wayland-sessions/budgie-desktop.desktop to use the command line entry "-C ~/.config/budgie-desktop/labwc/" to execute labwc doesn't appear to work.

I don't know why - possibly a bug in labwc ... or cannot use it in conjunction with -S /usr/bin/budgie-desktop

For the moment - lets revert the change until we find a better answer / an alternative way to specify the labwc configuration folder.

Using an environment variable XDG_CONFIG_HOME as per https://forum.xfce.org/viewtopic.php?id=18013 would impact all apps config files.  Doesn't seem to be the logical way forward.

If there is a better way I'm all ears.


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
