### PR TITLE
data: Specify the wlroots portal backend for screensharing

### DIFF
--- a/data/budgie-portals.conf
+++ b/data/budgie-portals.conf
@@ -1,3 +1,6 @@
 [preferred]
-# Use xdg-desktop-portal-gtk for every portal interface
+# Use xdg-desktop-portal-gtk for every portal interface...
 default=gtk
+# ... except for the ScreenCast and Screenshot
+org.freedesktop.impl.portal.ScreenCast=wlr
+org.freedesktop.impl.portal.Screenshot=wlr


### PR DESCRIPTION
## Description

This specifies that the wlroots xdg-desktop-portal backend should be used for sharing the screen.

Tested by trying to share just a screen or just a window in Discord, and seeing that it works.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
