### PR TITLE
Only invoke one action per popup - closes #700

### DIFF
--- a/src/daemon/notifications/dbus.vala
+++ b/src/daemon/notifications/dbus.vala
@@ -220,7 +220,7 @@
 		 * If replaces_id is not 0, the returned value is the same value as replaces_id.
 		 */
 		[DBus (name="Notify")]
-		public uint32 notication_received(
+		public uint32 notification_received(
 			string app_name,
 			uint32 replaces_id,
 			string app_icon,

--- a/src/daemon/notifications/popup.vala
+++ b/src/daemon/notifications/popup.vala
@@ -152,6 +152,7 @@ namespace Budgie.Notifications {
 		public bool did_interact { get; private set; default = false; }
 
 		private Body? body;
+		private bool actioned = false; /* only ActionInvoked once for each popup */
 
 		/**
 		 * Signal emitted when an action is clicked.
@@ -192,7 +193,10 @@ namespace Budgie.Notifications {
 			if (this.notification.actions.length > 0) {
 				var actions = new ActionBox(this.notification.actions, this.notification.hints.contains("action-icons"));
 				actions.ActionInvoked.connect((action_key) => {
-					this.ActionInvoked(action_key);
+					if (!this.actioned) {
+						this.ActionInvoked(action_key);
+					}
+					this.actioned = true;
 					this.dismiss();
 				});
 				content_box.pack_start(actions, true, true, 0);
@@ -218,7 +222,10 @@ namespace Budgie.Notifications {
 			// Handle interaction events
 			this.button_release_event.connect(() => {
 				if (has_default_action) {
-					this.ActionInvoked("default");
+					if (!this.actioned) {
+						this.ActionInvoked("default");
+					}
+					this.actioned = true;
 				} else if (this.notification.app_info != null && !has_actions) {
 					// Try to launch the application that generated the notification
 					try {
@@ -252,7 +259,10 @@ namespace Budgie.Notifications {
 			if (new_notif.actions.length > 0) {
 				var actions = new ActionBox(new_notif.actions, new_notif.hints.contains("action-icons"));
 				actions.ActionInvoked.connect((action_key) => {
-					this.ActionInvoked(action_key);
+					if (!this.actioned) {
+						this.ActionInvoked(action_key);
+					}
+					this.actioned = true;
 				});
 				content_box.pack_start(actions, false, true, 0);
 			}


### PR DESCRIPTION
## Description
as per #700 - this ensures only one action is ever invoked per popup

Note - this PR also fixes an obvious spelling issue for a member function

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
