### PR TITLE
Always display the authentication user using a label if there is just one account - closes #624

### DIFF
--- a/src/dialogs/polkit/dialog.ui
+++ b/src/dialogs/polkit/dialog.ui
@@ -94,6 +94,35 @@
               </packing>
             </child>
             <child>
+              <object class="GtkLabel" id="label_username">
+                <property name="visible">False</property>
+                <property name="can-focus">False</property>
+                <property name="halign">start</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">8</property>
+                <property name="label" translatable="yes">Username:</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label_identity">
+                <property name="visible">False</property>
+                <property name="can-focus">False</property>
+                <property name="halign">start</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">8</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left-attach">2</property>
+                <property name="top-attach">2</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkLabel" id="label_message">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
@@ -117,20 +146,6 @@
               <object class="GtkComboBox" id="combobox_idents">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">2</property>
-                <property name="width">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label_identity">
-                <property name="visible">False</property>
-                <property name="can-focus">False</property>
-                <property name="halign">center</property>
-                <property name="margin-top">2</property>
-                <property name="margin-bottom">2</property>
               </object>
               <packing>
                 <property name="left-attach">1</property>

--- a/src/dialogs/polkit/dialog.ui
+++ b/src/dialogs/polkit/dialog.ui
@@ -125,6 +125,20 @@
               </packing>
             </child>
             <child>
+              <object class="GtkLabel" id="label_identity">
+                <property name="visible">False</property>
+                <property name="can-focus">False</property>
+                <property name="halign">center</property>
+                <property name="margin-top">2</property>
+                <property name="margin-bottom">2</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">2</property>
+                <property name="width">2</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkLabel" id="label_error">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>

--- a/src/dialogs/polkit/polkitdialog.vala
+++ b/src/dialogs/polkit/polkitdialog.vala
@@ -25,6 +25,9 @@ namespace Budgie {
 		private unowned Gtk.ComboBox? combobox_idents;
 
 		[GtkChild]
+		private unowned Gtk.Label? label_username;
+
+		[GtkChild]
 		private unowned Gtk.Label? label_identity;
 
 		[GtkChild]
@@ -309,6 +312,7 @@ namespace Budgie {
 			}
 
 			if (length == 1) {
+				label_username.set_visible(true);
 				label_identity.set_visible(true);
 				label_identity.set_label(name);
 			}

--- a/src/dialogs/polkit/polkitdialog.vala
+++ b/src/dialogs/polkit/polkitdialog.vala
@@ -25,6 +25,9 @@ namespace Budgie {
 		private unowned Gtk.ComboBox? combobox_idents;
 
 		[GtkChild]
+		private unowned Gtk.Label? label_identity;
+
+		[GtkChild]
 		private unowned Gtk.Label? label_prompt;
 
 		[GtkChild]
@@ -280,9 +283,8 @@ namespace Budgie {
 
 			int length = 0;
 
+			string? name = null;
 			foreach (unowned Polkit.Identity? ident in idents) {
-				string? name = null;
-
 				if (ident is Polkit.UnixUser) {
 					unowned Posix.Passwd? pwd = Posix.getpwuid(((Polkit.UnixUser) ident).get_uid());
 					name = "%s".printf(pwd.pw_name);
@@ -304,6 +306,11 @@ namespace Budgie {
 			if (length < 2) {
 				combobox_idents.no_show_all = true;
 				combobox_idents.hide();
+			}
+
+			if (length == 1) {
+				label_identity.set_visible(true);
+				label_identity.set_label(name);
 			}
 		}
 


### PR DESCRIPTION
## Description
See the headline

In summary - if just one authentication user is found then display the name via a centered label.  

Currently, if just one authentication user is found the name was hidden.

This ensure that even if a standard account is being used, the standard user will know they should be authenticating using the primary administrator.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
