### PR TITLE
Make the screenshot dialog less aggressive to start when finding libxfce4windowing details.

### DIFF
--- a/src/dialogs/screenshot/budgie-screenshot-dialog.desktop.in.in
+++ b/src/dialogs/screenshot/budgie-screenshot-dialog.desktop.in.in
@@ -6,7 +6,4 @@ Terminal=false
 Categories=GNOME;GTK;System;Core;
 NoDisplay=true
 StartupNotify=true
-X-GNOME-AutoRestart=true
-X-GNOME-Autostart-Notify=true
-X-GNOME-Autostart-Phase=Desktop
 OnlyShowIn=Budgie

--- a/src/dialogs/screenshot/screenshot.vala
+++ b/src/dialogs/screenshot/screenshot.vala
@@ -61,7 +61,7 @@ namespace Budgie {
 				to return a reference, so lets loop until we get a reference ... but
 				don't try indefinitely
 			 */
-			 Timeout.add(200, ()=> {
+			 Timeout.add_seconds(1, ()=> {
 				 primary_monitor = libxfce4windowing.Screen.get_default().get_primary_monitor();
 				 if (primary_monitor != null || loop++ > 10) {
 					 gdk_monitor = primary_monitor.get_gdk_monitor();

--- a/src/session/budgie-desktop-screenshotdialog.desktop.in.in
+++ b/src/session/budgie-desktop-screenshotdialog.desktop.in.in
@@ -7,5 +7,6 @@ Exec=@libexecdir@/budgie-screenshot-dialog
 TryExec=@libexecdir@/budgie-screenshot-dialog
 OnlyShowIn=Budgie;
 NoDisplay=true
-X-GNOME-Autostart-Phase=Application
+X-GNOME-AutoRestart=true
 X-GNOME-Autostart-Notify=true
+X-GNOME-Autostart-Phase=Application


### PR DESCRIPTION
## Description
We are expecting too much of libxfce4windowing to get the monitor and scale details on startup - the underlying wayland client needs more time after the desktop has initialised. This is intended to prevent crashing if the necessary details are not found before first usage. As a fallback, the autostart session is amended to restart if necessary if at anytime the dialog fails for any reason.

Taken together this makes the screenshot capability experience more robust



### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
