### PR TITLE
icon-tasklist: Fix crash when icons are removed

### DIFF
--- a/src/panel/applets/icon-tasklist/widgets/ButtonPopover.vala
+++ b/src/panel/applets/icon-tasklist/widgets/ButtonPopover.vala
@@ -149,8 +149,8 @@ public class ButtonPopover : Gtk.Popover {
 	}
 
 	private void on_pin_clicked() {
-		pinned = !pinned;
 		hide();
+		pinned = !pinned;
 	}
 
 	private void on_new_instance_clicked() {


### PR DESCRIPTION
## Description

Trying to hide a popover that's been deleted is bad, m'kay?

Fixes https://github.com/BuddiesOfBudgie/budgie-desktop/issues/658

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
