### PR TITLE
Full Screen shortcut

### DIFF
--- a/src/bridges/labwc/rc.xml
+++ b/src/bridges/labwc/rc.xml
@@ -262,7 +262,7 @@
 		<keybind bridge="wm.keybindings/unmaximize" key="W-Down">
 			<action name="UnMaximize" direction="both" />
 		</keybind>
-		<keybind bridge="wm.keybindings/toggle-fullscreen" key="undefined">
+		<keybind bridge="wm.keybindings/toggle-fullscreen" key="A-F11">
 			<action name="ToggleFullscreen" />
 		</keybind>
 		<keybind bridge="wm.keybindings/toggle-maximized" key="A-F10">


### PR DESCRIPTION
This is just a small change so that the shortcut to activate full screen is already activated by default.

## Description
<Info on what this pull request adds>


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
