### PR TITLE
session: Add a start script to start the compositor

### DIFF
--- a/src/bridges/labwc/labwc_bridge.py
+++ b/src/bridges/labwc/labwc_bridge.py
@@ -59,7 +59,7 @@ class Bridge:
             mainloop=quit()
 
     def user_config(self, config_file="rc.xml"):
-        return os.path.join(GLib.get_user_config_dir(), "labwc", config_file)
+        return os.path.join(GLib.get_user_config_dir(), "budgie-desktop", "labwc", config_file)
 
     # writes the labwc rc.xml file back
     def write_config(self):
@@ -101,30 +101,8 @@ class Bridge:
         self.log = logging.getLogger('labwc_bridge')
         self.log.addHandler(JournalHandler())
 
-        path,search_path = self.search_for_config("environment")
-        if path == None:
-            return
-
-        try:
-            if path != search_path[0]:
-                folder = self.user_config("")
-                os.makedirs(folder, exist_ok=True)
-                shutil.copy(path, search_path[0])
-        except Exception as e:
-            self.log.critical("Failed to copy " + path + " to " + search_path[0])
-            self.log.critical(e)
-            return
-
         path, search_path = self.search_for_config("menu.xml")
         if path == None:
-            return
-
-        try:
-            if path != search_path[0]:
-                shutil.copy(path, search_path[0])
-        except Exception as e:
-            self.log.critical("Failed to copy " + path + " to " + search_path[0])
-            self.log.critical(e)
             return
 
         try:

--- a/src/bridges/labwc/meson.build
+++ b/src/bridges/labwc/meson.build
@@ -21,15 +21,15 @@ install_data(
 
 install_data(
     'rc.xml',
-    install_dir: join_paths(datadir, 'budgie-desktop')
+    install_dir: join_paths(datadir, 'budgie-desktop', 'labwc')
 )
 
 install_data(
     'environment',
-    install_dir: join_paths(datadir, 'budgie-desktop')
+    install_dir: join_paths(datadir, 'budgie-desktop', 'labwc')
 )
 
 install_data(
     'menu.xml',
-    install_dir: join_paths(datadir, 'budgie-desktop')
+    install_dir: join_paths(datadir, 'budgie-desktop', 'labwc')
 )

--- a/src/daemon/manager.vala
+++ b/src/daemon/manager.vala
@@ -22,6 +22,7 @@ namespace Budgie {
 	 */
 	[SingleInstance]
 	public class WaylandClient : GLib.Object {
+		private libxfce4windowing.Screen? screen = null;
 		private unowned libxfce4windowing.Monitor? primary_monitor=null;
 
 		public bool is_initialised() { return primary_monitor != null; }
@@ -30,7 +31,9 @@ namespace Budgie {
 
 		public WaylandClient() {
 			if (primary_monitor != null) return;
-			libxfce4windowing.Screen.get_default().monitors_changed.connect(on_monitors_changed);
+
+			screen = libxfce4windowing.Screen.get_default();
+			screen.monitors_changed.connect(on_monitors_changed);
 			on_monitors_changed();
 		}
 
@@ -42,7 +45,7 @@ namespace Budgie {
 			   don't try indefinitely
 			*/
 			Timeout.add(200, ()=> {
-				primary_monitor = libxfce4windowing.Screen.get_default().get_primary_monitor();
+				primary_monitor = screen.get_primary_monitor();
 				if (primary_monitor != null || loop++ > 10) {
 					monitor_res = primary_monitor.get_logical_geometry();
 					gdk_monitor = primary_monitor.get_gdk_monitor();

--- a/src/session/budgie-desktop.desktop.in.in
+++ b/src/session/budgie-desktop.desktop.in.in
@@ -1,8 +1,8 @@
 [Desktop Entry]
+Version=1.0
 _Name=Budgie Desktop
 _Comment=This session logs you into the Budgie Desktop using labwc as the window manager
-Exec=@labwc_bindir@/labwc -S @bindir@/budgie-desktop
-TryExec=@labwc_bindir@/labwc
+Exec=@bindir@/startbudgiedesktop
 Icon=
 Type=Application
 DesktopNames=Budgie

--- a/src/session/meson.build
+++ b/src/session/meson.build
@@ -40,6 +40,8 @@ session_data.set('SESSION_COMPONENTS', ';'.join(session_components))
 session_data.set('prefix', join_paths(get_option('prefix')))
 # Set bindir to budgie-desktop
 session_data.set('bindir', bindir)
+# Set datadir to budgie-desktop
+session_data.set('datadir', datadir)
 
 # Set bindir to labwc
 labwc_bindir = get_option('labwc-bindir')
@@ -77,6 +79,14 @@ custom_target('desktop-file-session-main',
     command : [intltool, '--desktop-style', podir, '@INPUT@', '@OUTPUT@'],
     install : true,
     install_dir : join_paths(datadir, 'gnome-session', 'sessions'),
+)
+
+# Write /usr/bin/startbudgiedesktop script
+configure_file(
+    input: 'startbudgiedesktop.in',
+    output: 'startbudgiedesktop',
+    configuration: session_data,
+    install_dir: join_paths(get_option('prefix'), get_option('bindir')),
 )
 
 # Write /usr/bin/budgie-desktop script

--- a/src/session/startbudgiedesktop.in
+++ b/src/session/startbudgiedesktop.in
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+OPTS=""
+for OPT in "$@"; do
+    if test "${OPT}" = "--help"; then
+        # Print help and exit
+        echo "Usage:"
+        echo "  startbudgiedesktop [OPTIONS...]"
+        echo
+        echo "Options:"
+        echo "  --help                   Show help options"
+        echo
+
+        exit 0
+    else
+        # Append to opts
+        OPTS="$OPTS $OPT"
+    fi
+done
+
+BUDGIE_SESSION_COMPOSITOR="1"
+export BUDGIE_SESSION_COMPOSITOR
+
+# Set the XDG_RUNTIME_DIR if we can not get it in systems
+# without systemd
+if [ -z "${XDG_RUNTIME_DIR}" ]; then
+    if [ -d "/run/user" ]; then
+        XDG_RUNTIME_DIR="/run/user/$(id -ru)"
+        export XDG_RUNTIME_DIR
+    else
+        if [ -d "/var/run/user" ]; then
+            XDG_RUNTIME_DIR="/var/run/user/$(id -ru)"
+            export XDG_RUNTIME_DIR
+        else
+            XDG_RUNTIME_DIR="/tmp/${USER}-runtime"
+            export XDG_RUNTIME_DIR
+        fi
+    fi
+fi
+if [ ! -e "${XDG_RUNTIME_DIR}" ]; then
+    echo "XDG_RUNTIME_DIR is invalid or does not exist!"
+    echo "Creating XDG_RUNTIME_DIR..."
+    mkdir -p -m 0700 "${XDG_RUNTIME_DIR}" || {
+        echo "Unable to create runtime directory ${XDG_RUNTIME_DIR}!"
+        exit 1
+    }
+fi
+
+# freedesktop specifications mandate that the definition
+# of XDG_SESSION_TYPE should be respected
+XDG_SESSION_TYPE="wayland"
+export XDG_SESSION_TYPE
+
+# Make sure all toolkits use their Wayland backend
+#
+# For Gtk applications also the x11 backend as a safe fallback
+if [ -z "${GDK_BACKEND}" ]; then
+    GDK_BACKEND="wayland,x11"
+    export GDK_BACKEND
+fi
+if [ -z "${QT_QPA_PLATFORM}" ]; then
+    QT_QPA_PLATFORM="wayland"
+    export QT_QPA_PLATFORM
+fi
+
+# In many OS the wayland backend for clutter does not work, so
+# use the safe "gdk" backend instead
+if [ -z "${CLUTTER_BACKEND}" ]; then
+    CLUTTER_BACKEND="gdk"
+    export CLUTTER_BACKEND
+fi
+if [ -z "${SDL_VIDEODRIVER}" ]; then
+    SDL_VIDEODRIVER="wayland"
+    export SDL_VIDEODRIVER
+fi
+
+# This is default for current firefox/thunderbird
+MOZ_ENABLE_WAYLAND="1"
+export MOZ_ENABLE_WAYLAND
+
+default_compositor="labwc"
+
+# See if we can use the --session option of labwc (available since 0.7.2)
+startup_option="--session"
+"$default_compositor" --help | grep -q -- "$startup_option" || startup_option="--startup"
+
+# Create specific labwc directory for Budgie
+if [ ! -d "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc" ]; then
+    mkdir -p "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc"
+fi
+
+# Copy specific labwc configuration file for Budgie
+if [ ! -f "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/rc.xml" ]; then
+    cp -p @datadir@/budgie-desktop/labwc/rc.xml "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/rc.xml"
+fi
+
+# Copy specific labwc environment file for Budgie
+if [ ! -f "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/environment" ]; then
+    cp -p @datadir@/budgie-desktop/labwc/environment "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/environment"
+fi
+
+# Copy specific labwc menu file for Budgie
+if [ ! -f "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/menu.xml" ]; then
+    cp -p @datadir@/budgie-desktop/labwc/menu.xml "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/menu.xml"
+fi
+
+# Budgie will use its own config directory and config file to avoid
+# conflict with current labwc setup and avoid launching anything
+# from ~/.config/labwc/autostart
+BUDGIE_SESSION_COMPOSITOR="${OPTS:-labwc --config-dir ${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc --config ${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/rc.xml $startup_option @bindir@/budgie-desktop}"
+
+# Start a D-Bus session if there isn't one already.
+if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
+    BUDGIE_SESSION_COMPOSITOR="dbus-run-session -- ${BUDGIE_SESSION_COMPOSITOR}"
+fi
+
+# workaround https://github.com/canonical/lightdm/issues/63
+if [ -n "$XDG_VTNR" ] && [ -f "/sys/devices/virtual/tty/tty0/active" ]; then
+    VT_TEST_CNT=1
+    while true; do
+        CURRENT_VT=$(cat /sys/devices/virtual/tty/tty0/active)
+        if [ "$CURRENT_VT" = "tty$XDG_VTNR" ]; then
+            break
+        fi
+        VT_TEST_CNT=$((VT_TEST_CNT + 1))
+        if [ "$VT_TEST_CNT" -gt 100 ]; then
+            echo "VT $XDG_VTNR is expected but the switch did not happen in the last second, continuing anyway."
+            break
+        fi
+        sleep 0.01
+    done
+fi
+
+# start budgie-session normally
+exec ${BUDGIE_SESSION_COMPOSITOR}


### PR DESCRIPTION
## Description

This is adapted from Xfce4. The start script sets some environment variables, copies our configuration files to the correct user directory, and starts the Wayland compositor, in our case, labwc. They support running different compositors by passing it as an argument to the script, which is why they have the whole Opts thing. We may want that in the future too, so I left it in.

Note that if you're using Budgie Daemon V2, it will no longer autostart, presumably because we now set the config-dir for labwc. We could probably copy over the `/etc/xdg/labwc/autostart` file to the local dir, but I don't like that, because what if someone already has other entries in there, and I don't want to add yet another way to auto-start a program.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
