### PR TITLE
Ensure usage levelbar granularity is set to 0px so that bar values display correctly - closes #735

### DIFF
--- a/src/raven/widgets/usage-monitor/usage_monitor.vala
+++ b/src/raven/widgets/usage-monitor/usage_monitor.vala
@@ -279,6 +279,7 @@ private class UsageMonitorRow {
 		label.set_markup(name);
 
 		bar = new Gtk.LevelBar();
+		bar.name="usagemonitorlevel";
 		bar.add_offset_value("full", 0.8);
 		bar.add_offset_value("high", 0.9);
 		bar.add_offset_value("low", 1.0);
@@ -288,6 +289,23 @@ private class UsageMonitorRow {
 		bar.margin_bottom = 6;
 		bar.hexpand = true;
 		bar.set_size_request(-1, 10);
+
+		try {
+			// alot of themes set the min-width for a level-bar - which isn't great since it
+			// limits the granularity - rather than asking each individual theme to change lets
+			// override a themes wishes in this very specific use-case
+			var css = new Gtk.CssProvider ();
+			css.load_from_data ("""
+				levelbar#usagemonitorlevel trough block {min-width: 0px; }
+			""");
+			Gtk.StyleContext.add_provider_for_screen (
+				Gdk.Screen.get_default (),
+				css,
+				Gtk.STYLE_PROVIDER_PRIORITY_USER
+			);
+		} catch (Error e) {
+			warning("Could not load levelbar CSS %s", e.message);
+		}
 
 		percentage = new Gtk.Label(null);
 		percentage.xalign = 1.0f;


### PR DESCRIPTION
## Description
as per title

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
