### PR TITLE
Enabling thumbnail in Labwc window switcher

### DIFF
--- a/src/bridges/labwc/rc.xml
+++ b/src/bridges/labwc/rc.xml
@@ -321,7 +321,7 @@
 	<snapping>
 		<range>10</range>
 	</snapping>
-	<windowSwitcher allWorkspaces="no" />
+	<windowSwitcher style="thumbnail" allWorkspaces="no" />
 	<mouse>
 		<doubleClickTime>400</doubleClickTime>
 	</mouse>


### PR DESCRIPTION
This is just a small tweak to enable thumbnails in the Labwc window switcher. This feature was added in the latest version, 0.9.2.

I tested it on Ubuntu Budgie 25.04 with Budgie 10.9.2, and it worked without any issues.