### PR TITLE
Hide 'hicolor' from icon theme list

### DIFF
--- a/src/panel/settings/themes.vala
+++ b/src/panel/settings/themes.vala
@@ -66,6 +66,7 @@ public class ThemeScanner : GLib.Object {
 		"Papirus-Adapta",
 		"Papirus-Adapta-Nokto",
 		"breeze",
+		"hicolor",
 		"solus-sc"
 	};
 


### PR DESCRIPTION
## Description
The `hicolor` theme is used as a generic fallback if no theme-specific icon is found, and it's not a complete icon theme.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
