### PR TITLE
Show screenshot tool only in Budgie session

### DIFF
--- a/src/dialogs/screenshot/budgie-screenshot.desktop.in
+++ b/src/dialogs/screenshot/budgie-screenshot.desktop.in
@@ -7,3 +7,4 @@ Icon=org.buddiesofbudgie.BudgieScreenshot
 Categories=Utility;
 Keywords=Screenshot;Snip;
 StartupWMClass=org.buddiesofbudgie.BudgieScreenshot
+OnlyShowIn=Budgie


### PR DESCRIPTION
## Description
It relies on the `org.buddiesofbudgie.BudgieScreenshotControl` D-Bus interface, which is specific for Budgie.


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
