### PR TITLE
build: Actually bump budgie-raven-plugin version

### DIFF
--- a/src/plugin/raven/meson.build
+++ b/src/plugin/raven/meson.build
@@ -91,7 +91,7 @@ pkgconfig.generate(
     name: 'budgie-raven-plugin',
     description: 'Budgie Raven Plugin Library',
     version: '2',
-    filebase: 'budgie-raven-plugin-1.0',
+    filebase: 'budgie-raven-plugin-2.0',
     subdirs: 'budgie-desktop',
     libraries: ['-L${libdir}', '-lbudgie-raven-plugin'],
     requires: [


### PR DESCRIPTION


## Description

With #743, this is now generating `budgie-raven-plugin-1.0.pc` and `budgie-raven-plugin-2.0.vapi`. According to [Vala docs] the VAPI filename must match the pkgconfig filename which is no longer the case now.

I am trying to rebuild reverse deps with #743 on NixOS and found e.g. `budgie-analogue-clock-applet` start failing to build (even after switching to `budgie-2.0`) because it failed to find a VAPI file for `budgie-raven-plugin-1.0`.

[Vala docs]: https://docs.vala.dev/developer-guides/bindings/writing-a-vapi-manually/02-00-getting-started/02-01-the-vapi-file.html

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
