### PR TITLE
panel/plugin-manager: Don't free object owned by hashtable

### DIFF
--- a/src/panel/plugin/plugin-manager.c
+++ b/src/panel/plugin/plugin-manager.c
@@ -378,7 +378,10 @@ BudgieAppletInfo *budgie_panel_plugin_manager_load_applet_instance(BudgiePanelPl
 	}
 
 	plugin_name = g_settings_get_string(settings, BUDGIE_APPLET_KEY_NAME);
-	info = g_hash_table_lookup(self->plugins, plugin_name);
+
+	if (g_hash_table_contains(self->plugins, plugin_name)) {
+		info = g_object_ref(g_hash_table_lookup(self->plugins, plugin_name));
+	}
 
 	// Check if the plugin has been loaded
 	if (!PEAS_IS_PLUGIN_INFO(info)) {


### PR DESCRIPTION
## Description

When calling `g_hash_table_lookup`, the returned data is not owned by
the caller. We should ref it so we don't have to worry about freeing vs
not freeing later.

Ref https://github.com/BuddiesOfBudgie/budgie-desktop/issues/766

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
