### PR TITLE
BudgieMenuWindow: Adapt to new BCC deskop file name

### DIFF
--- a/src/panel/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/src/panel/applets/budgie-menu/BudgieMenuWindow.vala
@@ -109,7 +109,7 @@ public class BudgieMenuWindow : Gtk.Popover {
 		});
 
 		this.system_settings_button.clicked.connect(() => {
-			this.open_desktop_entry("budgie-control-center.desktop");
+			this.open_desktop_entry("org.buddiesofbudgie.ControlCenter.desktop");
 			this.hide();
 		});
 


### PR DESCRIPTION



## Description

ref: https://github.com/BuddiesOfBudgie/budgie-control-center/commit/81e2c011d4aa220b91f363db5e81962fec5dbb3f


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)

<details><summary>I did tested this on 10.10...</summary>


![budgie-10-10](https://github.com/user-attachments/assets/5ecc6f8b-2d65-4e2e-bc7f-e8b436ee1a2b)


</details>
