### PR TITLE
Add environment variables to help running budgie in virtualbox and also help electron based apps think they are still running in GNOME

### DIFF
--- a/src/session/startbudgielabwc.in
+++ b/src/session/startbudgielabwc.in
@@ -76,6 +76,14 @@ if [ -z "${SDL_VIDEODRIVER}" ]; then
     export SDL_VIDEODRIVER
 fi
 
+# Add a wlroots helper to allow running in VirtualBox
+if grep -q "VirtualBox" /sys/class/dmi/id/product_name 2>/dev/null; then
+    export WLR_RENDERER=pixman
+fi
+
+# Add a helper for electron based apps to think they are running under GNOME
+export GNOME_DESKTOP_SESSION_ID=this-is-deprecated
+
 # This is default for current firefox/thunderbird
 MOZ_ENABLE_WAYLAND="1"
 export MOZ_ENABLE_WAYLAND


### PR DESCRIPTION
## Description
Helper environment variables as per the title

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
