### PR TITLE
Remember display changes from wdisplays

### DIFF
--- a/src/daemon/main.vala
+++ b/src/daemon/main.vala
@@ -75,6 +75,24 @@ public static int main(string[] args) {
 	end_dialog.Opened.connect(settings.do_disable_quietly); // When we've opened the EndSession dialog, disable Caffeine Mode
 	end_dialog.Closed.connect(settings.do_disable_quietly); // When we've closed the EndSession dialog as well, ensure Caffeine mode is disabled
 
+
+	string[] cmd = { "/usr/libexec/budgie-desktop/wlr-display-manager" };
+	var env = Environ.get();
+	Pid pid;
+
+	try {
+		Process.spawn_async(
+			null,
+			cmd,
+			env,
+			SEARCH_PATH_FROM_ENVP,
+			null,
+			out pid
+		);
+	} catch (SpawnError e) {
+		warning("Error starting wlr-display-manager: %s", e.message);
+	}
+
 	/* Enter main loop */
 	Gtk.main();
 

--- a/src/daemon/meson.build
+++ b/src/daemon/meson.build
@@ -109,3 +109,42 @@ install_data(
     files('notifications/20_buddiesofbudgie.budgie-desktop.notifications.gschema.override'),
     install_dir: join_paths(datadir, 'glib-2.0', 'schemas')
 )
+
+wayland_client = dependency('wayland-client')
+wayland_scanner = dependency('wayland-scanner', native: true)
+wayland_protocols = dependency('wayland-protocols')
+
+# Get wayland-scanner executable
+prog_scanner = find_program(
+  wayland_scanner.get_variable('wayland_scanner'),
+  native: true,
+)
+
+# Protocol XML file
+protocol_xml = files('wlr-output-management-unstable-v1.xml')
+
+# Generate protocol header
+protocol_header = custom_target(
+  'wlr-output-management-unstable-v1-client-protocol.h',
+  input: protocol_xml,
+  output: '@BASENAME@-client-protocol.h',
+  command: [prog_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+)
+
+# Generate protocol code
+protocol_code = custom_target(
+  'wlr-output-management-unstable-v1-protocol.c',
+  input: protocol_xml,
+  output: '@BASENAME@-protocol.c',
+  command: [prog_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+)
+
+# Build the executable
+executable('wlr-display-manager',
+  'wlr-display-manager.c',
+  protocol_header,
+  protocol_code,
+  dependencies: [wayland_client],
+  install: true,
+  install_dir: libexecdir,
+)

--- a/src/daemon/wlr-display-manager.c
+++ b/src/daemon/wlr-display-manager.c
@@ -1,0 +1,347 @@
+#define _POSIX_C_SOURCE 200809L
+// Alternatively: #define _XOPEN_SOURCE 700
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <wayland-client.h>
+
+// You'll need to generate this header from the protocol XML
+// wayland-scanner client-header < wlr-output-management-unstable-v1.xml > wlr-output-management-unstable-v1-client-protocol.h
+// wayland-scanner private-code < wlr-output-management-unstable-v1.xml > wlr-output-management-unstable-v1-protocol.c
+#include "wlr-output-management-unstable-v1-client-protocol.h"
+
+#define CONFIG_FILE_PATH "%s/.config/budgie-desktop/labwc/displays.conf"
+#define MAX_PATH 512
+#define MAX_OUTPUT 2048
+
+typedef struct {
+    struct wl_display *display;
+    struct wl_registry *registry;
+    struct zwlr_output_manager_v1 *output_manager;
+    char config_path[MAX_PATH];
+    int apply_on_start;
+} AppState;
+
+// Get full config file path
+static void get_config_path(char *buf, size_t size) {
+    const char *home = getenv("HOME");
+    if (!home) {
+        fprintf(stderr, "HOME environment variable not set\n");
+        exit(1);
+    }
+    snprintf(buf, size, CONFIG_FILE_PATH, home);
+}
+
+// Create config directory if it doesn't exist
+static void ensure_config_dir(const char *config_path) {
+    char dir[MAX_PATH];
+    snprintf(dir, sizeof(dir), "%s", config_path);
+    
+    // Find last slash to get directory
+    char *last_slash = strrchr(dir, '/');
+    if (last_slash) {
+        *last_slash = '\0';
+        mkdir(dir, 0755); // Create if doesn't exist, ignore error if exists
+    }
+}
+
+// Execute wlr-randr and capture output
+static char* run_wlr_randr(void) {
+    FILE *fp;
+    char *output = NULL;
+    size_t output_size = 0;
+    size_t output_len = 0;
+    char buffer[256];
+    
+    fp = popen("wlr-randr 2>&1", "r");
+    if (!fp) {
+        perror("Failed to run wlr-randr");
+        return NULL;
+    }
+    
+    // Read all output
+    while (fgets(buffer, sizeof(buffer), fp) != NULL) {
+        size_t len = strlen(buffer);
+        if (output_len + len + 1 > output_size) {
+            output_size = output_size ? output_size * 2 : 4096;
+            output = realloc(output, output_size);
+            if (!output) {
+                pclose(fp);
+                return NULL;
+            }
+        }
+        strcpy(output + output_len, buffer);
+        output_len += len;
+    }
+    
+    pclose(fp);
+    return output;
+}
+
+// Save current display configuration
+static int save_config(AppState *state) {
+    char *config_data = run_wlr_randr();
+    if (!config_data) {
+        fprintf(stderr, "Failed to get display configuration\n");
+        return -1;
+    }
+    
+    ensure_config_dir(state->config_path);
+    
+    FILE *fp = fopen(state->config_path, "w");
+    if (!fp) {
+        fprintf(stderr, "Failed to open config file: %s\n", strerror(errno));
+        free(config_data);
+        return -1;
+    }
+    
+    fputs(config_data, fp);
+    fclose(fp);
+    free(config_data);
+    
+    printf("Display configuration saved to %s\n", state->config_path);
+    return 0;
+}
+
+// Parse a line for key-value pair
+static int parse_line(const char *line, const char *key, char *value, size_t value_size) {
+    const char *pos = strstr(line, key);
+    if (!pos) return 0;
+    
+    pos += strlen(key);
+    while (*pos == ' ' || *pos == ':') pos++;
+    
+    size_t i = 0;
+    while (*pos && *pos != '\n' && i < value_size - 1) {
+        value[i++] = *pos++;
+    }
+    value[i] = '\0';
+    
+    // Trim trailing whitespace
+    while (i > 0 && (value[i-1] == ' ' || value[i-1] == '\r')) {
+        value[--i] = '\0';
+    }
+    
+    return 1;
+}
+
+// Apply saved display configuration
+static int apply_config(AppState *state) {
+    FILE *fp = fopen(state->config_path, "r");
+    if (!fp) {
+        fprintf(stderr, "No saved configuration found at %s\n", state->config_path);
+        return -1;
+    }
+    
+    char line[512];
+    char output_name[128] = {0};
+    char cmd[1024] = {0};
+    char value[256];
+    int in_output = 0;
+    
+    printf("Applying saved display configuration...\n");
+    
+    while (fgets(line, sizeof(line), fp)) {
+        // New output section
+        if (line[0] != ' ' && line[0] != '\n' && line[0] != '\t') {
+            // Execute previous command if we have one
+            if (cmd[0] != '\0') {
+                printf("Executing: %s\n", cmd);
+                system(cmd);
+                cmd[0] = '\0';
+            }
+            
+            // Extract output name (first word on line)
+            sscanf(line, "%127s", output_name);
+            snprintf(cmd, sizeof(cmd), "wlr-randr --output %s", output_name);
+            in_output = 1;
+            continue;
+        }
+        
+        if (!in_output) continue;
+        
+        // Parse output properties
+        if (parse_line(line, "Enabled:", value, sizeof(value))) {
+            if (strcmp(value, "no") == 0) {
+                snprintf(cmd, sizeof(cmd), "wlr-randr --output %s --off", output_name);
+                system(cmd);
+                cmd[0] = '\0';
+                in_output = 0;
+                continue;
+            }
+        }
+        
+        if (parse_line(line, "Position:", value, sizeof(value))) {
+            strcat(cmd, " --pos ");
+            strcat(cmd, value);
+        }
+        
+        // Look for current mode line (contains "current")
+        if (strstr(line, "current") && strstr(line, "px")) {
+            int width, height;
+            float refresh;
+            if (sscanf(line, " %dx%d px, %f Hz", &width, &height, &refresh) == 3) {
+                char mode[128];
+                snprintf(mode, sizeof(mode), " --mode %dx%d@%.3fHz", width, height, refresh);
+                strcat(cmd, mode);
+            }
+        }
+        
+        if (parse_line(line, "Transform:", value, sizeof(value))) {
+            if (strcmp(value, "normal") != 0) {
+                strcat(cmd, " --transform ");
+                strcat(cmd, value);
+            }
+        }
+        
+        if (parse_line(line, "Scale:", value, sizeof(value))) {
+            strcat(cmd, " --scale ");
+            strcat(cmd, value);
+        }
+    }
+    
+    // Execute last command
+    if (cmd[0] != '\0') {
+        printf("Executing: %s\n", cmd);
+        system(cmd);
+    }
+    
+    fclose(fp);
+    printf("Display configuration applied\n");
+    return 0;
+}
+
+// Wayland output manager done event - fires when display config changes
+static void output_manager_done(void *data,
+        struct zwlr_output_manager_v1 *manager, uint32_t serial) {
+    AppState *state = (AppState *)data;
+    printf("Display configuration change detected\n");
+    save_config(state);
+}
+
+static void output_manager_head(void *data,
+        struct zwlr_output_manager_v1 *manager,
+        struct zwlr_output_head_v1 *head) {
+    // We don't need to track individual heads for this use case
+}
+
+static void output_manager_finished(void *data,
+        struct zwlr_output_manager_v1 *manager) {
+    fprintf(stderr, "Output manager finished, exiting\n");
+    exit(1);
+}
+
+static const struct zwlr_output_manager_v1_listener output_manager_listener = {
+    .head = output_manager_head,
+    .done = output_manager_done,
+    .finished = output_manager_finished,
+};
+
+// Registry handler to find the output manager
+static void registry_global(void *data, struct wl_registry *registry,
+        uint32_t name, const char *interface, uint32_t version) {
+    AppState *state = (AppState *)data;
+    
+    if (strcmp(interface, zwlr_output_manager_v1_interface.name) == 0) {
+        state->output_manager = wl_registry_bind(registry, name,
+            &zwlr_output_manager_v1_interface, 2);
+        zwlr_output_manager_v1_add_listener(state->output_manager,
+            &output_manager_listener, state);
+    }
+}
+
+static void registry_global_remove(void *data, struct wl_registry *registry,
+        uint32_t name) {
+    // Not handling removal
+}
+
+static const struct wl_registry_listener registry_listener = {
+    .global = registry_global,
+    .global_remove = registry_global_remove,
+};
+
+static void print_usage(const char *prog) {
+    printf("Usage: %s [OPTIONS]\n", prog);
+    printf("Monitor and manage wlroots display configuration\n\n");
+    printf("Options:\n");
+    printf("  -a, --apply    Apply saved configuration and exit\n");
+    printf("  -s, --save     Save current configuration and exit\n");
+    printf("  -m, --monitor  Monitor for changes and auto-save (default)\n");
+    printf("  -h, --help     Show this help message\n");
+}
+
+int main(int argc, char *argv[]) {
+    AppState state = {0};
+    int mode = 0; // 0=monitor, 1=apply, 2=save
+    
+    get_config_path(state.config_path, sizeof(state.config_path));
+    
+    // Parse arguments
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-a") == 0 || strcmp(argv[i], "--apply") == 0) {
+            mode = 1;
+        } else if (strcmp(argv[i], "-s") == 0 || strcmp(argv[i], "--save") == 0) {
+            mode = 2;
+        } else if (strcmp(argv[i], "-m") == 0 || strcmp(argv[i], "--monitor") == 0) {
+            mode = 0;
+        } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+            print_usage(argv[0]);
+            return 0;
+        } else {
+            fprintf(stderr, "Unknown option: %s\n", argv[i]);
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+    
+    // Handle one-shot modes
+    if (mode == 1) {
+        return apply_config(&state);
+    } else if (mode == 2) {
+        return save_config(&state);
+    }
+    
+    // Monitor mode - connect to Wayland
+    printf("Starting display configuration monitor...\n");
+    printf("Config file: %s\n", state.config_path);
+    
+    state.display = wl_display_connect(NULL);
+    if (!state.display) {
+        fprintf(stderr, "Failed to connect to Wayland display\n");
+        return 1;
+    }
+    
+    state.registry = wl_display_get_registry(state.display);
+    wl_registry_add_listener(state.registry, &registry_listener, &state);
+    
+    // Initial roundtrip to get globals
+    wl_display_roundtrip(state.display);
+    
+    if (!state.output_manager) {
+        fprintf(stderr, "Compositor does not support wlr-output-management protocol\n");
+        wl_display_disconnect(state.display);
+        return 1;
+    }
+    
+    printf("Connected to compositor, monitoring for display changes...\n");
+    
+    // Apply config on startup if it exists
+    if (access(state.config_path, F_OK) == 0) {
+        printf("Applying saved configuration on startup...\n");
+        apply_config(&state);
+    }
+    
+    // Event loop
+    while (wl_display_dispatch(state.display) != -1) {
+        // Continue processing events
+    }
+    
+    wl_display_disconnect(state.display);
+    return 0;
+}

--- a/src/daemon/wlr-output-management-unstable-v1.xml
+++ b/src/daemon/wlr-output-management-unstable-v1.xml
@@ -1,0 +1,611 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_output_management_unstable_v1">
+  <copyright>
+    Copyright © 2019 Purism SPC
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <description summary="protocol to configure output devices">
+    This protocol exposes interfaces to obtain and modify output device
+    configuration.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_output_manager_v1" version="4">
+    <description summary="output device configuration manager">
+      This interface is a manager that allows reading and writing the current
+      output device configuration.
+
+      Output devices that display pixels (e.g. a physical monitor or a virtual
+      output in a window) are represented as heads. Heads cannot be created nor
+      destroyed by the client, but they can be enabled or disabled and their
+      properties can be changed. Each head may have one or more available modes.
+
+      Whenever a head appears (e.g. a monitor is plugged in), it will be
+      advertised via the head event. Immediately after the output manager is
+      bound, all current heads are advertised.
+
+      Whenever a head's properties change, the relevant wlr_output_head events
+      will be sent. Not all head properties will be sent: only properties that
+      have changed need to.
+
+      Whenever a head disappears (e.g. a monitor is unplugged), a
+      wlr_output_head.finished event will be sent.
+
+      After one or more heads appear, change or disappear, the done event will
+      be sent. It carries a serial which can be used in a create_configuration
+      request to update heads properties.
+
+      The information obtained from this protocol should only be used for output
+      configuration purposes. This protocol is not designed to be a generic
+      output property advertisement protocol for regular clients. Instead,
+      protocols such as xdg-output should be used.
+    </description>
+
+    <event name="head">
+      <description summary="introduce a new head">
+        This event introduces a new head. This happens whenever a new head
+        appears (e.g. a monitor is plugged in) or after the output manager is
+        bound.
+      </description>
+      <arg name="head" type="new_id" interface="zwlr_output_head_v1"/>
+    </event>
+
+    <event name="done">
+      <description summary="sent all information about current configuration">
+        This event is sent after all information has been sent after binding to
+        the output manager object and after any subsequent changes. This applies
+        to child head and mode objects as well. In other words, this event is
+        sent whenever a head or mode is created or destroyed and whenever one of
+        their properties has been changed. Not all state is re-sent each time
+        the current configuration changes: only the actual changes are sent.
+
+        This allows changes to the output configuration to be seen as atomic,
+        even if they happen via multiple events.
+
+        A serial is sent to be used in a future create_configuration request.
+      </description>
+      <arg name="serial" type="uint" summary="current configuration serial"/>
+    </event>
+
+    <request name="create_configuration">
+      <description summary="create a new output configuration object">
+        Create a new output configuration object. This allows to update head
+        properties.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_output_configuration_v1"/>
+      <arg name="serial" type="uint"/>
+    </request>
+
+    <request name="stop">
+      <description summary="stop sending events">
+        Indicates the client no longer wishes to receive events for output
+        configuration changes. However the compositor may emit further events,
+        until the finished event is emitted.
+
+        The client must not send any more requests after this one.
+      </description>
+    </request>
+
+    <event name="finished" type="destructor">
+      <description summary="the compositor has finished with the manager">
+        This event indicates that the compositor is done sending manager events.
+        The compositor will destroy the object immediately after sending this
+        event, so it will become invalid and the client should release any
+        resources associated with it.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="zwlr_output_head_v1" version="4">
+    <description summary="output device">
+      A head is an output device. The difference between a wl_output object and
+      a head is that heads are advertised even if they are turned off. A head
+      object only advertises properties and cannot be used directly to change
+      them.
+
+      A head has some read-only properties: modes, name, description and
+      physical_size. These cannot be changed by clients.
+
+      Other properties can be updated via a wlr_output_configuration object.
+
+      Properties sent via this interface are applied atomically via the
+      wlr_output_manager.done event. No guarantees are made regarding the order
+      in which properties are sent.
+    </description>
+
+    <event name="name">
+      <description summary="head name">
+        This event describes the head name.
+
+        The naming convention is compositor defined, but limited to alphanumeric
+        characters and dashes (-). Each name is unique among all wlr_output_head
+        objects, but if a wlr_output_head object is destroyed the same name may
+        be reused later. The names will also remain consistent across sessions
+        with the same hardware and software configuration.
+
+        Examples of names include 'HDMI-A-1', 'WL-1', 'X11-1', etc. However, do
+        not assume that the name is a reflection of an underlying DRM
+        connector, X11 connection, etc.
+
+        If this head matches a wl_output, the wl_output.name event must report
+        the same name.
+
+        The name event is sent after a wlr_output_head object is created. This
+        event is only sent once per object, and the name does not change over
+        the lifetime of the wlr_output_head object.
+      </description>
+      <arg name="name" type="string"/>
+    </event>
+
+    <event name="description">
+      <description summary="head description">
+        This event describes a human-readable description of the head.
+
+        The description is a UTF-8 string with no convention defined for its
+        contents. Examples might include 'Foocorp 11" Display' or 'Virtual X11
+        output via :1'. However, do not assume that the name is a reflection of
+        the make, model, serial of the underlying DRM connector or the display
+        name of the underlying X11 connection, etc.
+
+        If this head matches a wl_output, the wl_output.description event must
+        report the same name.
+
+        The description event is sent after a wlr_output_head object is created.
+        This event is only sent once per object, and the description does not
+        change over the lifetime of the wlr_output_head object.
+      </description>
+      <arg name="description" type="string"/>
+    </event>
+
+    <event name="physical_size">
+      <description summary="head physical size">
+        This event describes the physical size of the head. This event is only
+        sent if the head has a physical size (e.g. is not a projector or a
+        virtual device).
+
+        The physical size event is sent after a wlr_output_head object is created. This
+        event is only sent once per object, and the physical size does not change over
+        the lifetime of the wlr_output_head object.
+      </description>
+      <arg name="width" type="int" summary="width in millimeters of the output"/>
+      <arg name="height" type="int" summary="height in millimeters of the output"/>
+    </event>
+
+    <event name="mode">
+      <description summary="introduce a mode">
+        This event introduces a mode for this head. It is sent once per
+        supported mode.
+      </description>
+      <arg name="mode" type="new_id" interface="zwlr_output_mode_v1"/>
+    </event>
+
+    <event name="enabled">
+      <description summary="head is enabled or disabled">
+        This event describes whether the head is enabled. A disabled head is not
+        mapped to a region of the global compositor space.
+
+        When a head is disabled, some properties (current_mode, position,
+        transform and scale) are irrelevant.
+      </description>
+      <arg name="enabled" type="int" summary="zero if disabled, non-zero if enabled"/>
+    </event>
+
+    <event name="current_mode">
+      <description summary="current mode">
+        This event describes the mode currently in use for this head. It is only
+        sent if the output is enabled.
+      </description>
+      <arg name="mode" type="object" interface="zwlr_output_mode_v1"/>
+    </event>
+
+    <event name="position">
+      <description summary="current position">
+        This events describes the position of the head in the global compositor
+        space. It is only sent if the output is enabled.
+      </description>
+      <arg name="x" type="int"
+        summary="x position within the global compositor space"/>
+      <arg name="y" type="int"
+        summary="y position within the global compositor space"/>
+    </event>
+
+    <event name="transform">
+      <description summary="current transformation">
+        This event describes the transformation currently applied to the head.
+        It is only sent if the output is enabled.
+      </description>
+      <arg name="transform" type="int" enum="wl_output.transform"/>
+    </event>
+
+    <event name="scale">
+      <description summary="current scale">
+        This events describes the scale of the head in the global compositor
+        space. It is only sent if the output is enabled.
+      </description>
+      <arg name="scale" type="fixed"/>
+    </event>
+
+    <event name="finished">
+      <description summary="the head has disappeared">
+        This event indicates that the head is no longer available. The head
+        object becomes inert. Clients should send a destroy request and release
+        any resources associated with it.
+      </description>
+    </event>
+
+    <!-- Version 2 additions -->
+
+    <event name="make" since="2">
+      <description summary="head manufacturer">
+        This event describes the manufacturer of the head.
+
+        Together with the model and serial_number events the purpose is to
+        allow clients to recognize heads from previous sessions and for example
+        load head-specific configurations back.
+
+        It is not guaranteed this event will be ever sent. A reason for that
+        can be that the compositor does not have information about the make of
+        the head or the definition of a make is not sensible in the current
+        setup, for example in a virtual session. Clients can still try to
+        identify the head by available information from other events but should
+        be aware that there is an increased risk of false positives.
+
+        If sent, the make event is sent after a wlr_output_head object is
+        created and only sent once per object. The make does not change over
+        the lifetime of the wlr_output_head object.
+
+        It is not recommended to display the make string in UI to users. For
+        that the string provided by the description event should be preferred.
+      </description>
+      <arg name="make" type="string"/>
+    </event>
+
+    <event name="model" since="2">
+      <description summary="head model">
+        This event describes the model of the head.
+
+        Together with the make and serial_number events the purpose is to
+        allow clients to recognize heads from previous sessions and for example
+        load head-specific configurations back.
+
+        It is not guaranteed this event will be ever sent. A reason for that
+        can be that the compositor does not have information about the model of
+        the head or the definition of a model is not sensible in the current
+        setup, for example in a virtual session. Clients can still try to
+        identify the head by available information from other events but should
+        be aware that there is an increased risk of false positives.
+
+        If sent, the model event is sent after a wlr_output_head object is
+        created and only sent once per object. The model does not change over
+        the lifetime of the wlr_output_head object.
+
+        It is not recommended to display the model string in UI to users. For
+        that the string provided by the description event should be preferred.
+      </description>
+      <arg name="model" type="string"/>
+    </event>
+
+    <event name="serial_number" since="2">
+      <description summary="head serial number">
+        This event describes the serial number of the head.
+
+        Together with the make and model events the purpose is to allow clients
+        to recognize heads from previous sessions and for example load head-
+        specific configurations back.
+
+        It is not guaranteed this event will be ever sent. A reason for that
+        can be that the compositor does not have information about the serial
+        number of the head or the definition of a serial number is not sensible
+        in the current setup. Clients can still try to identify the head by
+        available information from other events but should be aware that there
+        is an increased risk of false positives.
+
+        If sent, the serial number event is sent after a wlr_output_head object
+        is created and only sent once per object. The serial number does not
+        change over the lifetime of the wlr_output_head object.
+
+        It is not recommended to display the serial_number string in UI to
+        users. For that the string provided by the description event should be
+        preferred.
+      </description>
+      <arg name="serial_number" type="string"/>
+    </event>
+
+    <!-- Version 3 additions -->
+
+    <request name="release" type="destructor" since="3">
+      <description summary="destroy the head object">
+        This request indicates that the client will no longer use this head
+        object.
+      </description>
+    </request>
+
+    <!-- Version 4 additions -->
+
+    <enum name="adaptive_sync_state" since="4">
+      <entry name="disabled" value="0" summary="adaptive sync is disabled"/>
+      <entry name="enabled" value="1" summary="adaptive sync is enabled"/>
+    </enum>
+
+    <event name="adaptive_sync" since="4">
+      <description summary="current adaptive sync state">
+        This event describes whether adaptive sync is currently enabled for
+        the head or not. Adaptive sync is also known as Variable Refresh
+        Rate or VRR.
+      </description>
+      <arg name="state" type="uint" enum="adaptive_sync_state"/>
+    </event>
+  </interface>
+
+  <interface name="zwlr_output_mode_v1" version="3">
+    <description summary="output mode">
+      This object describes an output mode.
+
+      Some heads don't support output modes, in which case modes won't be
+      advertised.
+
+      Properties sent via this interface are applied atomically via the
+      wlr_output_manager.done event. No guarantees are made regarding the order
+      in which properties are sent.
+    </description>
+
+    <event name="size">
+      <description summary="mode size">
+        This event describes the mode size. The size is given in physical
+        hardware units of the output device. This is not necessarily the same as
+        the output size in the global compositor space. For instance, the output
+        may be scaled or transformed.
+      </description>
+      <arg name="width" type="int" summary="width of the mode in hardware units"/>
+      <arg name="height" type="int" summary="height of the mode in hardware units"/>
+    </event>
+
+    <event name="refresh">
+      <description summary="mode refresh rate">
+        This event describes the mode's fixed vertical refresh rate. It is only
+        sent if the mode has a fixed refresh rate.
+      </description>
+      <arg name="refresh" type="int" summary="vertical refresh rate in mHz"/>
+    </event>
+
+    <event name="preferred">
+      <description summary="mode is preferred">
+        This event advertises this mode as preferred.
+      </description>
+    </event>
+
+    <event name="finished">
+      <description summary="the mode has disappeared">
+        This event indicates that the mode is no longer available. The mode
+        object becomes inert. Clients should send a destroy request and release
+        any resources associated with it.
+      </description>
+    </event>
+
+    <!-- Version 3 additions -->
+
+    <request name="release" type="destructor" since="3">
+      <description summary="destroy the mode object">
+        This request indicates that the client will no longer use this mode
+        object.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_output_configuration_v1" version="4">
+    <description summary="output configuration">
+      This object is used by the client to describe a full output configuration.
+
+      First, the client needs to setup the output configuration. Each head can
+      be either enabled (and configured) or disabled. It is a protocol error to
+      send two enable_head or disable_head requests with the same head. It is a
+      protocol error to omit a head in a configuration.
+
+      Then, the client can apply or test the configuration. The compositor will
+      then reply with a succeeded, failed or cancelled event. Finally the client
+      should destroy the configuration object.
+    </description>
+
+    <enum name="error">
+      <entry name="already_configured_head" value="1"
+        summary="head has been configured twice"/>
+      <entry name="unconfigured_head" value="2"
+        summary="head has not been configured"/>
+      <entry name="already_used" value="3"
+        summary="request sent after configuration has been applied or tested"/>
+    </enum>
+
+    <request name="enable_head">
+      <description summary="enable and configure a head">
+        Enable a head. This request creates a head configuration object that can
+        be used to change the head's properties.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_output_configuration_head_v1"
+        summary="a new object to configure the head"/>
+      <arg name="head" type="object" interface="zwlr_output_head_v1"
+        summary="the head to be enabled"/>
+    </request>
+
+    <request name="disable_head">
+      <description summary="disable a head">
+        Disable a head.
+      </description>
+      <arg name="head" type="object" interface="zwlr_output_head_v1"
+        summary="the head to be disabled"/>
+    </request>
+
+    <request name="apply">
+      <description summary="apply the configuration">
+        Apply the new output configuration.
+
+        In case the configuration is successfully applied, there is no guarantee
+        that the new output state matches completely the requested
+        configuration. For instance, a compositor might round the scale if it
+        doesn't support fractional scaling.
+
+        After this request has been sent, the compositor must respond with an
+        succeeded, failed or cancelled event. Sending a request that isn't the
+        destructor is a protocol error.
+      </description>
+    </request>
+
+    <request name="test">
+      <description summary="test the configuration">
+        Test the new output configuration. The configuration won't be applied,
+        but will only be validated.
+
+        Even if the compositor succeeds to test a configuration, applying it may
+        fail.
+
+        After this request has been sent, the compositor must respond with an
+        succeeded, failed or cancelled event. Sending a request that isn't the
+        destructor is a protocol error.
+      </description>
+    </request>
+
+    <event name="succeeded">
+      <description summary="configuration changes succeeded">
+        Sent after the compositor has successfully applied the changes or
+        tested them.
+
+        Upon receiving this event, the client should destroy this object.
+
+        If the current configuration has changed, events to describe the changes
+        will be sent followed by a wlr_output_manager.done event.
+      </description>
+    </event>
+
+    <event name="failed">
+      <description summary="configuration changes failed">
+        Sent if the compositor rejects the changes or failed to apply them. The
+        compositor should revert any changes made by the apply request that
+        triggered this event.
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <event name="cancelled">
+      <description summary="configuration has been cancelled">
+        Sent if the compositor cancels the configuration because the state of an
+        output changed and the client has outdated information (e.g. after an
+        output has been hotplugged).
+
+        The client can create a new configuration with a newer serial and try
+        again.
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the output configuration">
+        Using this request a client can tell the compositor that it is not going
+        to use the configuration object anymore. Any changes to the outputs
+        that have not been applied will be discarded.
+
+        This request also destroys wlr_output_configuration_head objects created
+        via this object.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_output_configuration_head_v1" version="4">
+    <description summary="head configuration">
+      This object is used by the client to update a single head's configuration.
+
+      It is a protocol error to set the same property twice.
+    </description>
+
+    <enum name="error">
+      <entry name="already_set" value="1" summary="property has already been set"/>
+      <entry name="invalid_mode" value="2" summary="mode doesn't belong to head"/>
+      <entry name="invalid_custom_mode" value="3" summary="mode is invalid"/>
+      <entry name="invalid_transform" value="4" summary="transform value outside enum"/>
+      <entry name="invalid_scale" value="5" summary="scale negative or zero"/>
+      <entry name="invalid_adaptive_sync_state" value="6" since="4"
+        summary="invalid enum value used in the set_adaptive_sync request"/>
+    </enum>
+
+    <request name="set_mode">
+      <description summary="set the mode">
+        This request sets the head's mode.
+      </description>
+      <arg name="mode" type="object" interface="zwlr_output_mode_v1"/>
+    </request>
+
+    <request name="set_custom_mode">
+      <description summary="set a custom mode">
+        This request assigns a custom mode to the head. The size is given in
+        physical hardware units of the output device. If set to zero, the
+        refresh rate is unspecified.
+
+        It is a protocol error to set both a mode and a custom mode.
+      </description>
+      <arg name="width" type="int" summary="width of the mode in hardware units"/>
+      <arg name="height" type="int" summary="height of the mode in hardware units"/>
+      <arg name="refresh" type="int" summary="vertical refresh rate in mHz or zero"/>
+    </request>
+
+    <request name="set_position">
+      <description summary="set the position">
+        This request sets the head's position in the global compositor space.
+      </description>
+      <arg name="x" type="int" summary="x position in the global compositor space"/>
+      <arg name="y" type="int" summary="y position in the global compositor space"/>
+    </request>
+
+    <request name="set_transform">
+      <description summary="set the transform">
+        This request sets the head's transform.
+      </description>
+      <arg name="transform" type="int" enum="wl_output.transform"/>
+    </request>
+
+    <request name="set_scale">
+      <description summary="set the scale">
+        This request sets the head's scale.
+      </description>
+      <arg name="scale" type="fixed"/>
+    </request>
+
+    <!-- Version 4 additions -->
+
+    <request name="set_adaptive_sync" since="4">
+      <description summary="enable/disable adaptive sync">
+        This request enables/disables adaptive sync. Adaptive sync is also
+        known as Variable Refresh Rate or VRR.
+      </description>
+      <arg name="state" type="uint" enum="zwlr_output_head_v1.adaptive_sync_state"/>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
## Description
**This isn't meant for merging.**

This is just a patch to enable displays to remember what they were, position and scaling.  It will be reapplied when you login.

Requires wlr-randr and wdisplays - it hard-codes a daemon exe in /usr/libexec/budgie-desktop/wlr-display-manager launched from budgie-daemon.

Patch will be dropped from Debian/Ubuntu once budgie-desktop-services/budgie-display-configurator is accepted in Debian/Ubuntu and we (buddies) consider it is ready.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
