### PR TITLE
feat(session): Add BUDGIE_SESSION_VERSION for external tool handling

### DIFF
--- a/src/session/budgie-desktop.in
+++ b/src/session/budgie-desktop.in
@@ -13,6 +13,8 @@ if [ -z $XDG_CURRENT_DESKTOP ]; then
   export XDG_CURRENT_DESKTOP
 fi
 
+export BUDGIE_SESSION_VERSION=${BUDGIE_VERSION}
+
 @bindir@/org.buddiesofbudgie.Services &
 sleep 2
 


### PR DESCRIPTION
This is to improve external tools needing to be able to detect the version of Budgie in use e.g. xdg-utils

Related xdg-utils PR: https://gitlab.freedesktop.org/xdg/xdg-utils/-/merge_requests/161

## Description
An alternative solution for xdg-utils


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
