### PR TITLE
startbudgielabwc: Ensure labwc config is writable after copying

### DIFF
--- a/src/session/startbudgielabwc.in
+++ b/src/session/startbudgielabwc.in
@@ -98,16 +98,20 @@ fi
 # Copy specific labwc configuration file for Budgie
 if [ ! -f "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/rc.xml" ]; then
     cp -p @datadir@/budgie-desktop/labwc/rc.xml "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/rc.xml"
+    # This is needed on some immutable distributions like NixOS.
+    chmod u+w "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/rc.xml"
 fi
 
 # Copy specific labwc environment file for Budgie
 if [ ! -f "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/environment" ]; then
     cp -p @datadir@/budgie-desktop/labwc/environment "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/environment"
+    chmod u+w "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/environment"
 fi
 
 # Copy specific labwc menu file for Budgie
 if [ ! -f "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/menu.xml" ]; then
     cp -p @datadir@/budgie-desktop/labwc/menu.xml "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/menu.xml"
+    chmod u+w "${XDG_CONFIG_HOME:-${HOME}/.config}/budgie-desktop/labwc/menu.xml"
 fi
 
 # Budgie will use its own config directory and config file to avoid


### PR DESCRIPTION
On NixOS packages are immutable so the labwc config file would have 0444 mode when copied.

- Same as https://github.com/mate-desktop/mate-wayland-session/pull/15.



```
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]: Traceback (most recent call last):
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:   File "/nix/store/3fs4ppa4l3zaykp2fw6xyn85apm3n1iw-python3-3.13.11-env/lib/python3.13/xml/etree/ElementTree.py", line 749, in _get_writer
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:     write = file_or_filename.write
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:             ^^^^^^^^^^^^^^^^^^^^^^
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]: AttributeError: 'str' object has no attribute 'write'
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]: During handling of the above exception, another exception occurred:
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]: Traceback (most recent call last):
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:   File "/nix/store/0h124zd557vhaqarz3mv84a0b6niw71j-budgie-desktop-10.10.0/libexec/budgie-desktop/.labwc_bridge.py-wrapped", line 825, in <module>
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:     bridge = Bridge()
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:   File "/nix/store/0h124zd557vhaqarz3mv84a0b6niw71j-budgie-desktop-10.10.0/libexec/budgie-desktop/.labwc_bridge.py-wrapped", line 115, in __init__
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:     self.translate_menu_labels(search_path[0])
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:     ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:   File "/nix/store/0h124zd557vhaqarz3mv84a0b6niw71j-budgie-desktop-10.10.0/libexec/budgie-desktop/.labwc_bridge.py-wrapped", line 194, in translate_menu_labels
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:     self.menuet.write(path)
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:     ~~~~~~~~~~~~~~~~~^^^^^^
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:   File "/nix/store/3fs4ppa4l3zaykp2fw6xyn85apm3n1iw-python3-3.13.11-env/lib/python3.13/xml/etree/ElementTree.py", line 723, in write
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:     with _get_writer(file_or_filename, encoding) as (write, declared_encoding):
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:          ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:   File "/nix/store/3fs4ppa4l3zaykp2fw6xyn85apm3n1iw-python3-3.13.11-env/lib/python3.13/contextlib.py", line 141, in __enter__
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:     return next(self.gen)
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:   File "/nix/store/3fs4ppa4l3zaykp2fw6xyn85apm3n1iw-python3-3.13.11-env/lib/python3.13/xml/etree/ElementTree.py", line 754, in _get_writer
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:     with open(file_or_filename, "w", encoding=encoding,
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:          ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:               errors="xmlcharrefreplace") as file:
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 11 18:40:23 thinkbook org.buddiesofbudgie.labwc-bridge.desktop[4692]: PermissionError: [Errno 13] Permission denied: '/home/bobby285271/.config/budgie-desktop/labwc/menu.xml'

```

## Description
<Info on what this pull request adds>


### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
