### PR TITLE
Enable budgie to start with greetd - Closes #804

### DIFF
--- a/src/session/budgie-desktop.in
+++ b/src/session/budgie-desktop.in
@@ -8,18 +8,16 @@ if [ "$1" = "--version" ]; then
     exit 0
 fi
 
-if [ -z $XDG_CURRENT_DESKTOP ]; then
+if [ -z "${XDG_CURRENT_DESKTOP:-}" ] || ! printf %s "$XDG_CURRENT_DESKTOP" | grep -qi 'budgie'; then
   XDG_CURRENT_DESKTOP=Budgie
   export XDG_CURRENT_DESKTOP
 fi
 
 export BUDGIE_SESSION_VERSION=${BUDGIE_VERSION}
 
-@bindir@/org.buddiesofbudgie.Services &
-sleep 2
-
 # Wait until the server starts before launching the session
 compositor="@gsd_libexecdir@/budgie-session-compositor-ready"
 if command -v "$compositor" > /dev/null 2>&1 && "$compositor"; then
+  @bindir@/org.buddiesofbudgie.Services &
   exec budgie-session --builtin --session=org.buddiesofbudgie.BudgieDesktop $*
 fi


### PR DESCRIPTION
## Description
greetd doesn't start from the desktop file so it provides a dummy XDG_CURRENT_DESKTOP.  This PR ensures that if budgie isn't in the XDG_CURRENT_DESKTOP then force the setting of budgie. .
The PR also logically relocated desktop services to start after the compositor check and removes the sleep statement. This noticably allows the desktop to appear faster.

Tested with greetd + gtkgreeter. desktop appeared and XDG_CURRENT_DESKTOP was set to 'Budgie' - this proves that the if statement executed
Switched back to lightdm and confirmed XDG_CURRENT_DESKTOP was set to 'Budgie'

Modified /usr/share/wayland-session/budgie-desktop.desktop and changed to 'Budgie:wlroots'
logged out and logged in and confirmed that XDG_CURRENT_DESKTOP was set to 'Budgie:wlroots' i.e. as expected did not match the if statement

**Please do check this PR on your setups**

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
