### PR TITLE
Get keyboard layout from systemd-localed if input-sources is not set

### DIFF
--- a/src/bridges/labwc/labwc_bridge.py
+++ b/src/bridges/labwc/labwc_bridge.py
@@ -291,6 +291,20 @@ class Bridge:
                     else:
                         layout += "," + extract
 
+        # Get keyboard layout from systemd-localed service
+        if layout == "":
+            try:
+                layout = Gio.DBusProxy.new_sync(
+                    Gio.bus_get_sync(Gio.BusType.SYSTEM, None),
+                    0, None,
+                    "org.freedesktop.locale1",
+                    "/org/freedesktop/locale1",
+                    "org.freedesktop.locale1",
+                    None
+                ).get_cached_property("X11Layout").unpack()
+            except:
+                pass
+
         if layout == "":
             layout = "us" # default to at least a known keyboard layout
 


### PR DESCRIPTION
## Description
This adds a fallback to the layout configured in systemd-localed service before falling back to "us".

Note that in Budgie 10.9, the X11 layout from systemd-localed was read by `gsd-keyboard`, and configured the input-sources in GSettings according to this:
https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/blob/9add93c492bae5400138ee872bd64009dbf48350/plugins/keyboard/gsd-keyboard-manager.c#L117-164

But in Budgie 10.10, `gsd-keyboard` is not started, therefore the `sources` remains empty if not already configured:
```
gsettings get org.gnome.desktop.input-sources sources
@a(ss) []
```

So another option would be to start `gsd-keyboard` also in Budgie 10.10.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
