### PR TITLE
Remove GTK theme blacklist

### DIFF
--- a/src/panel/settings/themes.vala
+++ b/src/panel/settings/themes.vala
@@ -44,22 +44,6 @@ class ThemeInfo : GLib.Object {
 public class ThemeScanner : GLib.Object {
 	string[]? xdg_paths = null;
 
-	string[] gtk_theme_blacklist = {
-		"Adwaita",
-		"Breeze",
-		"Clearlooks",
-		"Crux",
-		"Default",
-		"Emacs",
-		"Industrial",
-		"Kv",
-		"Mist",
-		"Murrina",
-		"Raleigh",
-		"Redmond",
-		"ThinIce"
-	};
-
 	string[] icon_theme_blacklist = {
 		"Adwaita",
 		"HighContrast",
@@ -190,14 +174,6 @@ public class ThemeScanner : GLib.Object {
 		var test_path = "%s%s%s".printf(path, Path.DIR_SEPARATOR_S, "gtk.css");
 		if (!FileUtils.test(test_path, FileTest.EXISTS)) {
 			return false;
-		}
-
-		for (int index = 0; index < gtk_theme_blacklist.length; index++) {
-			string blacklisted_item = gtk_theme_blacklist[index];
-
-			if ((blacklisted_item == theme_name) || (theme_name.index_of(blacklisted_item) != -1)) {
-				return false;
-			}
 		}
 
 		unowned ThemeInfo? info = gtk_themes.lookup(theme_name);


### PR DESCRIPTION
## Description
Since commit 673231e658216ce72677985377c17ecf1ea839f3 the existence of the GTK3 CSS is explicitly checked, there is no need to add those themes to the blacklist which does not provide a GTK3 theme variant. The only themes that actually provide a GTK3 variant is Adwaita and Breeze, but these GTK themes work without issues, only the corresponding icon themes are problematic.

Those themes are already filtered out since they don't provide a GTK3 variant:
- Clearlooks: gtk2+openbox theme
- Crux: xfwm4 theme
- Default: gtk3 keybindings
- Emacs: gtk3 keybindings
- Industrial: gtk2 theme
- Kvantum: gtk2 theme
- Mist: gtk2 theme
- Murrina: gtk2 theme
- Raleigh: gtk3+metacity theme
- Redmond: xfwm4 theme
- ThinIce: gtk2 theme

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
