### PR TITLE
Don't overwrite settings on login

### DIFF
--- a/src/daemon/settings.vala
+++ b/src/daemon/settings.vala
@@ -107,7 +107,6 @@ namespace Budgie {
 
 
 			panel_settings.changed["dark-theme"].connect((key) => apply_dark_theme_pref());
-			apply_dark_theme_pref();
 
 			gnome_session_settings.changed["idle-delay"].connect(this.update_idle_delay);
 			gnome_power_settings.changed["idle-dim"].connect(this.update_idle_dim);
@@ -115,7 +114,6 @@ namespace Budgie {
 			gnome_power_settings.changed["sleep-inactive-battery-timeout"].connect(this.update_battery_timeout);
 
 			wm_settings.changed.connect(this.on_wm_settings_changed);
-			this.on_wm_settings_changed("button-style");
 
 			gnome_desktop_settings.changed.connect(this.on_gnome_desktop_settings_changed);
 			this.on_gnome_desktop_settings_changed("gtk-theme");

--- a/src/wm/20_solus-project.budgie.wm.gschema.override
+++ b/src/wm/20_solus-project.budgie.wm.gschema.override
@@ -14,3 +14,6 @@ picture-uri = 'file:///usr/share/backgrounds/budgie/default.jpg'
 [org.gnome.desktop.wm.keybindings:Budgie]
 switch-input-source = ['<Alt>Shift_L', '<Super>space', 'XF86Keyboard']
 switch-input-source-backward = ['<Super><Shift>space', '<Shift>XF86Keyboard']
+
+[org.gnome.desktop.interface:Budgie]
+color-scheme='prefer-dark'


### PR DESCRIPTION
## Description
Setting the `button-style` and `color-scheme` on start makes the session- dependent default values apply also for other sessions, and prevents the users to set custom values for these settings. Overwrite settings only when changed by the user, and rely on session-dependent GSettings override for the initial values.


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
