### PR TITLE
Autostart gsd-keyboard

### DIFF
--- a/src/session/meson.build
+++ b/src/session/meson.build
@@ -11,6 +11,7 @@ budgie_session_324_components = [
     'org.buddiesofbudgie.SettingsDaemon.Datetime',
     'org.buddiesofbudgie.SettingsDaemon.DiskUtilityNotify',
     'org.buddiesofbudgie.SettingsDaemon.Housekeeping',
+    'org.buddiesofbudgie.SettingsDaemon.Keyboard',
     'org.buddiesofbudgie.SettingsDaemon.Power',
     'org.buddiesofbudgie.SettingsDaemon.PrintNotifications',
     'org.buddiesofbudgie.SettingsDaemon.Rfkill',

--- a/src/session/settingsdaemon/org.buddiesofbudgie.SettingsDaemon.Keyboard.desktop.in
+++ b/src/session/settingsdaemon/org.buddiesofbudgie.SettingsDaemon.Keyboard.desktop.in
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Budgie Desktop keyboard configuration
+Exec=@gsd_libexecdir@/gsd-keyboard
+OnlyShowIn=Budgie;
+NoDisplay=true
+X-GNOME-Autostart-Phase=Initialization
+X-GNOME-Autostart-Notify=true
+X-GNOME-AutoRestart=true
+X-GNOME-HiddenUnderSystemd=true
+


### PR DESCRIPTION
## Description
It's needed to set the initial input sources based on the keyboard layout configured in systemd-localed.

Without this, the labwc bridge does not get the configured layout, and falls back to 'us'.
This is also used by the keyboard-layout applet.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
