### PR TITLE
Add option to disable sync with GtkSettings file

### DIFF
--- a/src/daemon/settings.vala
+++ b/src/daemon/settings.vala
@@ -118,6 +118,7 @@ namespace Budgie {
 			this.on_wm_settings_changed("button-style");
 
 			gnome_desktop_settings.changed.connect(this.on_gnome_desktop_settings_changed);
+			panel_settings.changed["sync-gtksettings-file"].connect(this.on_gnome_desktop_settings_changed);
 			this.on_gnome_desktop_settings_changed("gtk-theme");
 		}
 
@@ -126,7 +127,10 @@ namespace Budgie {
 		  apps such
 		*/
 		private void on_gnome_desktop_settings_changed(string key) {
+			if (!panel_settings.get_boolean("sync-gtksettings-file")) return;
+
 			string[] keys = {
+				"sync-gtksettings-file",
 				"gtk-theme",
 				"icon-theme",
 				"cursor-theme",

--- a/src/panel/com.solus-project.budgie-panel.gschema.xml
+++ b/src/panel/com.solus-project.budgie-panel.gschema.xml
@@ -153,6 +153,12 @@
       <description>Enabling this will show the built-in theme option for legacy theme, which is no longer fully supported.</description>
     </key>
 
+    <key type="b" name="sync-gtksettings-file">
+      <default>true</default>
+      <summary>Sync settings with GtkSettings file</summary>
+      <description>Enabling this will save the current cursor and theme settings in the user's local config settings.ini file.</description>
+    </key>
+
     <key enum="com.solus-project.budgie-panel.NotificationPosition" name="notification-position">
       <default>'BUDGIE_NOTIFICATION_POSITION_TOP_RIGHT'</default>
       <summary>Set the location of notifications</summary>


### PR DESCRIPTION
## Description
This allows the users to disable writing the cursor and theme settings in the user's local config settings.ini file. Saving into that file is not always desirable, because it's applied also for other sessions.


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
