### PR TITLE
Save window buttons layout directly to gnome wm schema

### DIFF
--- a/src/daemon/settings.vala
+++ b/src/daemon/settings.vala
@@ -114,9 +114,6 @@ namespace Budgie {
 			gnome_power_settings.changed["sleep-inactive-ac-timeout"].connect(this.update_ac_timeout);
 			gnome_power_settings.changed["sleep-inactive-battery-timeout"].connect(this.update_battery_timeout);
 
-			wm_settings.changed.connect(this.on_wm_settings_changed);
-			this.on_wm_settings_changed("button-style");
-
 			gnome_desktop_settings.changed.connect(this.on_gnome_desktop_settings_changed);
 			this.on_gnome_desktop_settings_changed("gtk-theme");
 		}
@@ -308,10 +305,6 @@ namespace Budgie {
 					bool attach = wm_settings.get_boolean(key); // Get our attach value
 					mutter_settings.set_boolean("attach-modal-dialogs", attach); // Update GNOME WM settings
 					break;
-				case "button-style":
-					ButtonPosition style = (ButtonPosition)wm_settings.get_enum(key);
-					this.set_button_style(style);
-					break;
 				case "center-windows":
 					bool center = wm_settings.get_boolean(key);
 					mutter_settings.set_boolean("center-new-windows", center);
@@ -342,30 +335,6 @@ namespace Budgie {
 			gnome_power_settings.set_int("sleep-inactive-ac-timeout", default_sleep_inactive_ac_timeout);
 			gnome_power_settings.set_int("sleep-inactive-battery-timeout", default_sleep_inactive_battery_timeout);
 			caffeine_settings_sync();
-		}
-
-		/**
-		* Set the button layout to one of left or traditional
-		*/
-		void set_button_style(ButtonPosition style) {
-			Variant? xset = null;
-			string? wm_set = null;
-
-			switch (style) {
-			case ButtonPosition.LEFT:
-				xset = this.new_filtered_xsetting("close,minimize,maximize:menu");
-				wm_set = "close,minimize,maximize:appmenu";
-				break;
-			case ButtonPosition.TRADITIONAL:
-			default:
-				xset = this.new_filtered_xsetting("menu:minimize,maximize,close");
-				wm_set = "appmenu:minimize,maximize,close";
-				break;
-			}
-
-			this.xoverrides.set_value("overrides", xset);
-			this.wm_settings.set_string("button-layout", wm_set);
-			this.gnome_wm_settings.set_value("button-layout", wm_set);
 		}
 
 		/**

--- a/src/dialogs/screenshot/screenshot.vala
+++ b/src/dialogs/screenshot/screenshot.vala
@@ -92,9 +92,9 @@ namespace Budgie {
 		public CurrentState() {
 			screenshot_settings = new GLib.Settings("org.buddiesofbudgie.budgie-desktop.screenshot");
 
-			buttonplacement = new GLib.Settings("com.solus-project.budgie-wm");
+			buttonplacement = new GLib.Settings("org.gnome.desktop.wm.preferences");
 
-			buttonplacement.changed["button-style"].connect(() => {
+			buttonplacement.changed["button-layout"].connect(() => {
 				fill_buttonpos();
 				buttonpos_changed();
 			});
@@ -117,7 +117,11 @@ namespace Budgie {
 		}
 
 		private void fill_buttonpos() {
-			buttonpos = (buttonplacement.get_string("button-style") =="left") ? ButtonPlacement.LEFT : ButtonPlacement.RIGHT;
+			if (buttonplacement.get_string("button-layout").has_prefix("close")) {
+				buttonpos = ButtonPlacement.LEFT;
+			} else {
+				buttonpos = ButtonPlacement.RIGHT;
+			}
 		}
 
 		public void statechanged(int n) {

--- a/src/panel/settings/settings_wm.vala
+++ b/src/panel/settings/settings_wm.vala
@@ -14,6 +14,7 @@ namespace Budgie {
 	* WindowsPage allows users to control window manager settings
 	*/
 	public class WindowsPage : Budgie.SettingsPage {
+		private Settings gnome_wm_settings;
 		private Settings budgie_wm_settings;
 		private Gtk.Switch center_windows;
 		private Gtk.Switch disable_night_light;
@@ -79,9 +80,9 @@ namespace Budgie {
 			var model = new Gtk.ListStore(2, typeof(string), typeof(string));
 			Gtk.TreeIter iter;
 			model.append(out iter);
-			model.set(iter, 0, "traditional", 1, _("Right (standard)"), -1);
+			model.set(iter, 0, "appmenu:minimize,maximize,close", 1, _("Right (standard)"), -1);
 			model.append(out iter);
-			model.set(iter, 0, "left", 1, _("Left"), -1);
+			model.set(iter, 0, "close,minimize,maximize:appmenu", 1, _("Left"), -1);
 			combo_layouts.set_model(model);
 			combo_layouts.set_id_column(0);
 
@@ -91,8 +92,9 @@ namespace Budgie {
 			combo_layouts.set_id_column(0);
 
 			/* Hook up settings */
+			gnome_wm_settings = new Settings("org.gnome.desktop.wm.preferences");
+			gnome_wm_settings.bind("button-layout", combo_layouts, "active-id", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings = new Settings("com.solus-project.budgie-wm");
-			budgie_wm_settings.bind("button-style", combo_layouts, "active-id", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("center-windows", center_windows, "active", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("disable-night-light-on-fullscreen", disable_night_light, "active", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("pause-notifications-on-fullscreen", pause_notifications, "active", SettingsBindFlags.DEFAULT);

--- a/src/wm/com.solus-project.budgie.wm.gschema.xml
+++ b/src/wm/com.solus-project.budgie.wm.gschema.xml
@@ -158,27 +158,6 @@
 			<description>The binding to use to show the power dialog</description>
 		</key>
 
-		<key name="button-layout" type="s">
-			<default>'appmenu:minimize,maximize,close'</default>
-			<summary>Arrangement of buttons on the titlebar</summary>
-			<description>
-				Arrangement of buttons on the titlebar. The value should be a string,
-				such as  "menu:minimize,maximize,spacer,close"; the colon separates
-				the  left corner of the window from the right corner, and  the button
-				names are comma-separated. Duplicate buttons are not allowed. Unknown
-				button names are silently ignored so that buttons can be added in
-				future metacity versions  without breaking older versions. A special
-				spacer tag can be used to insert some space between
-				two adjacent buttons.
-			</description>
-		</key>
-
-		<key enum="com.solus-project.budgie-wm.ButtonPosition" name="button-style">
-			<default>'traditional'</default>
-			<summary>Button layout style</summary>
-			<description>Which layout to use for window buttons</description>
-		</key>
-
 		<key enum="com.solus-project.budgie-wm.DesktopType" name="desktop-type-override">
 			<default>'none'</default>
 			<summary>Desktop Type Override</summary>


### PR DESCRIPTION
## Description
This eliminates the need to keep the values in sync with the setting stored in Budgie GSettings schema, and also allows users to set custom button layouts for their needs.


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
