### PR TITLE
Add support for different windows focus mode 

### DIFF
--- a/src/bridges/labwc/labwc_bridge.py
+++ b/src/bridges/labwc/labwc_bridge.py
@@ -18,6 +18,7 @@ from systemd.journal import JournalHandler
 import psutil
 import sys
 import gettext
+from enum import StrEnum
 
 import gi
 from gi.repository import Gio, GLib
@@ -441,7 +442,7 @@ class Bridge:
                 except IndexError:
                     pass
 
-        self.budgie_wm_changed(self.budgie_wm_settings, "focus-mode")
+        self.budgie_wm_changed(self.budgie_wm_settings, "window-focus-mode")
         self.budgie_wm_changed(self.budgie_wm_settings, "show-all-windows-tabswitcher")
         self.budgie_wm_changed(self.budgie_wm_settings, "edge-tiling")
         self.mutter_changed(self.mutter_settings, "center-new-windows")
@@ -494,14 +495,21 @@ class Bridge:
 
         updated = False
 
-        if key == "focus-mode":
+        if key == "window-focus-mode":
             path = "./focus/followMouse"
             bridge = root.find(path)
 
             if bridge == None:
                 return
 
-            if settings[key]:
+            class Mode(StrEnum):
+                CLICK = 'click'
+                SLOPPY = 'sloppy'
+                MOUSE = 'mouse'
+
+            focus_mode = settings[key]
+
+            if focus_mode != Mode.CLICK:
                 bridge.text = "yes"
             else:
                 bridge.text = "no"
@@ -514,7 +522,7 @@ class Bridge:
             if bridgeraise == None:
                 return
 
-            if settings[key]:
+            if focus_mode == Mode.MOUSE:
                 bridgeraise.text = "yes"
             else:
                 bridgeraise.text = "no"

--- a/src/panel/settings/settings_wm.vala
+++ b/src/panel/settings/settings_wm.vala
@@ -19,7 +19,7 @@ namespace Budgie {
 		private Gtk.Switch disable_night_light;
 		private Gtk.Switch pause_notifications;
 		private Gtk.ComboBox combo_layouts;
-		private Gtk.Switch switch_focus;
+		private Gtk.ComboBox combo_window_focus_mode;
 		private Gtk.Switch switch_tiling;
 		private Gtk.Switch switch_all_windows_tabswitcher;
 
@@ -63,10 +63,10 @@ namespace Budgie {
 				_("Windows will automatically tile when dragged into the top of the screen or the far corners.")
 			));
 
-			switch_focus = new Gtk.Switch();
-			grid.add_row(new SettingsRow(switch_focus,
-				_("Enable window focus change on mouse enter and leave"),
-				_("Enables window focus to apply when the mouse enters the window and unfocus when the mouse leaves the window.")
+			combo_window_focus_mode = new Gtk.ComboBox();
+			grid.add_row(new SettingsRow(combo_window_focus_mode,
+				_("Window focus mode"),
+				_("Choose how windows receive focus: click to focus; sloppy to focus without raising windows; mouse to focus with raising.")
 			));
 
 			switch_all_windows_tabswitcher = new Gtk.Switch();
@@ -75,7 +75,7 @@ namespace Budgie {
 				_("All tabs will be displayed in tab switcher regardless of the workspace in use.")
 			));
 
-			/* Button layout  */
+			/* Button layout */
 			var model = new Gtk.ListStore(2, typeof(string), typeof(string));
 			Gtk.TreeIter iter;
 			model.append(out iter);
@@ -90,14 +90,31 @@ namespace Budgie {
 			combo_layouts.add_attribute(render, "text", 1);
 			combo_layouts.set_id_column(0);
 
+			/* Window Focus Mode */
+			var focus_model = new Gtk.ListStore(2, typeof(string), typeof(string));
+			Gtk.TreeIter focus_iter;
+			focus_model.append(out focus_iter);
+			focus_model.set(focus_iter, 0, "click", 1, _("Click"), -1);
+			focus_model.append(out focus_iter);
+			focus_model.set(focus_iter, 0, "sloppy", 1, _("Sloppy"), -1);
+			focus_model.append(out focus_iter);
+			focus_model.set(focus_iter, 0, "mouse", 1, _("Mouse"), -1);
+			combo_window_focus_mode.set_model(focus_model);
+			combo_window_focus_mode.set_id_column(0);
+
+			var focus_render = new Gtk.CellRendererText();
+			combo_window_focus_mode.pack_start(focus_render, true);
+			combo_window_focus_mode.add_attribute(focus_render, "text", 1);
+			combo_window_focus_mode.set_id_column(0);
+
 			/* Hook up settings */
 			budgie_wm_settings = new Settings("com.solus-project.budgie-wm");
 			budgie_wm_settings.bind("button-style", combo_layouts, "active-id", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("center-windows", center_windows, "active", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("disable-night-light-on-fullscreen", disable_night_light, "active", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("pause-notifications-on-fullscreen", pause_notifications, "active", SettingsBindFlags.DEFAULT);
-			budgie_wm_settings.bind("edge-tiling", switch_tiling,  "active", SettingsBindFlags.DEFAULT);
-			budgie_wm_settings.bind("focus-mode", switch_focus, "active", SettingsBindFlags.DEFAULT);
+			budgie_wm_settings.bind("edge-tiling", switch_tiling, "active", SettingsBindFlags.DEFAULT);
+			budgie_wm_settings.bind("window-focus-mode", combo_window_focus_mode, "active-id", SettingsBindFlags.DEFAULT);
 			budgie_wm_settings.bind("show-all-windows-tabswitcher", switch_all_windows_tabswitcher, "active", SettingsBindFlags.DEFAULT);
 		}
 	}

--- a/src/wm/com.solus-project.budgie.wm.gschema.xml
+++ b/src/wm/com.solus-project.budgie.wm.gschema.xml
@@ -13,6 +13,12 @@
 		<value nick="nemo" value="3" />
 	</enum>
 
+	<enum id="com.solus-project.budgie-wm.FocusMode">
+		<value nick="click" value="0" />
+		<value nick="sloppy" value="1" />
+		<value nick="mouse" value="2" />
+  	</enum>
+
 	<schema path="/com/solus-project/budgie-wm/" id="com.solus-project.budgie-wm">
 		<key type="b" name="edge-tiling">
 			<default>true</default>
@@ -82,8 +88,14 @@
 
 		<key type="b" name="focus-mode">
 			<default>false</default>
-			<summary>Window focus mode to indicate how windows are activated</summary>
-			<description>This key overrides the key in org.gnome.desktop.wm.preferences when running Budgie.</description>
+			<summary>Enable window focus change on mouse enter and leave (DEPRECATED)</summary>
+			<description>This key is deprecated. Use 'focus-new-mode' instead.</description>
+		</key>
+
+		<key enum="com.solus-project.budgie-wm.FocusMode" name="window-focus-mode">
+			<default>'click'</default>
+			<summary>Window focus mode</summary>
+			<description>Determines how windows receive focus: 'click' requires clicking to focus, 'sloppy' focuses on mouse enter but requires click to raise, 'mouse' focuses and raises on mouse enter.</description>
 		</key>
 
 		<key type="b" name="enable-unredirect">


### PR DESCRIPTION
## Description
specifically allow sloppy focus as well as the standard click and the 10.9 mouse modes


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
