### PR TITLE
fix: fade-in animation of Raven

### DIFF
--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -423,7 +423,7 @@ namespace Budgie {
 		}
 
 		public override bool draw(Cairo.Context cr) {
-			if (nscale == 0.0 || nscale == 1.0) {
+			if (nscale == 1.0) {
 				return base.draw(cr);
 			}
 
@@ -488,9 +488,11 @@ namespace Budgie {
 			if (!this.get_settings().gtk_enable_animations) {
 				if (!exp) {
 					this.nscale = 0.0;
+					this.set_opacity(0.0);
 					this.hide();
 				} else {
 					this.nscale = 1.0;
+					this.set_opacity(1.0);
 					this.present();
 					this.grab_focus();
 					this.steal_focus();
@@ -521,6 +523,10 @@ namespace Budgie {
 			} else {
 				shadow.show();
 			}
+
+			// Raven is invisible before fade-in animation; make window visible before we start the animation
+			set_opacity(1.0);
+			show();
 
 			anim.start((a) => {
 				Budgie.Raven? r = a.widget as Budgie.Raven;


### PR DESCRIPTION
## Description
This PR tries to fix #837 and makes the fade-in animation visible.

- lines 527-530 were added to make the Raven window visible before the fade-in animation starts (so the user can see the animation)
- after that I noticed that on the second fade-in-click, Raven gets show instantly for a small amount of time (while nscale=0) and after that it starts to fade in; that was caused by line 426 which forwards the draw-call to the base-method which draws the RavenWindow at its total width; so I removed the `nscale == 0` condition in line 426
- now if Animations are disabled in budgie-settings the `set_expanded` method has an early exit branch in lines 488 till 500; once Raven was fade-out via an animation, the opacity was set to 0.0 in line 536; now if Animations get disabled, the opacity gets never set back to 1.0, and that's why there was a point, where Raven didn't show up anymore and a panel-reset was necessary; adding the opacity-change to the "AnimationAreDisabled-branch" brings it in line with the adjustments in the "AnimationsAreEnabled-branch"

**Important:** I wasn't able to test it in a multi-monitor setup. Hopefully someone can verify if there are side-effects I didn't catch.

Tested on ArchLinux only.

Please let me know if I can/should improve something.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
