### PR TITLE
Make OSD visible even on running fullscreen application

### DIFF
--- a/src/daemon/osd.vala
+++ b/src/daemon/osd.vala
@@ -125,7 +125,7 @@ namespace Budgie {
 			skip_taskbar_hint = true;
 
 			GtkLayerShell.init_for_window(this);
-			GtkLayerShell.set_layer(this, GtkLayerShell.Layer.TOP);
+			GtkLayerShell.set_layer(this, GtkLayerShell.Layer.OVERLAY);
 			GtkLayerShell.set_margin(this, GtkLayerShell.Edge.BOTTOM, 80);
 			GtkLayerShell.set_anchor(this, GtkLayerShell.Edge.BOTTOM, true);
 


### PR DESCRIPTION
## Description

Since v10.10 I noticed that the OSD for the volume control (and such) isn't visible if I switch a app into fullscreen-mode. For example playing a video full-screen in browser or VLC, or while running a game, etc.

The wlr-layer-shell provides [exactly 4 layers](https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_shell_v1:enum:layer). The "Top"-layer is for fullscreen-apps, and the "Overlay"-layer is exactly for such functionalities like the OSD. Till now the OSD in budgie-daemon was in layer "Top" .. ordering in the same layer is undefined.

I switched the OSD to the "Overlay" layer and I could finally see the "thing" again.

- tested on ArchLinux only
- tested with single monitor only

(Because of that small modification, I didn't open as issue first. If its needed, I'll do so.)

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
