### PR TITLE
Fix: app-group-activation while "show-all-windows-on-click"-mode is enabled

### DIFF
--- a/src/panel/applets/icon-tasklist/IconTasklistApplet.vala
+++ b/src/panel/applets/icon-tasklist/IconTasklistApplet.vala
@@ -543,7 +543,11 @@ public class IconTasklistApplet : Budgie.Applet {
 							}
 						}
 						if (last_active_window != null) {
-							last_active_window.activate(null, event.time);
+							try {
+								last_active_window.activate(null, event.time);
+							} catch (Error e) {
+								warning("Unable to activate last window '%s': %s", last_active_window.get_name(), e.message);
+							}
 						}
 					}
 				} else if (has_open_windows) { // Has open windows, toggle the visibility of the current/last active window


### PR DESCRIPTION
This PR is trying to fix #848, at least as much as possible

## Description

- The code now takes into account, if a clicked button-group is active/inactive while `show-all-windows-on-click` mode is enabled:
    - if the group is currently active, it minimizes the whole group (the active window last)
    - if the group was inactive, it activates all windows, but the previous-active-window last
- Additional it fixes `middle-click-launch-new-instance` condition error
    - till now the check was working inverted. If the setting was turned off, the user could start a new instance via middle-mouse click, and if the setting was enabled, it was not possible to use the middle-mouse-button

## Still open issues

The following two issues are still open if `show-all-windows-on-click` mode is enabled:

- if a app-group is activated via left-mouse-click, each window in the group gets activated one by one .. this makes all windows appear in the TaskSwitcher. I was looking for a function to bring a window to the top without activating it, but I couldn't find such a method
- If there are more than 2 instances of an app open and the whole group is minimized at once, it's not possible to restore the window-order correctly during group-activation again. Lets say there are 3 terminal instances overlapping each other. One is bigger but in the background, the other two are smaller and in front of the bigger one and overlapping it. The active window is restored correctly, as it is already on the top. The other two might be restored not in the same order they were before. I didn't find a way to fix this .. it might need a bigger rewrite. But as it is a minor issue, I didn't spend more time on it.

--
Please let me know, if I missed something.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
