### PR TITLE
Fix: Close windows via popover

### DIFF
--- a/src/panel/applets/icon-tasklist/widgets/ButtonPopover.vala
+++ b/src/panel/applets/icon-tasklist/widgets/ButtonPopover.vala
@@ -196,39 +196,29 @@ public class IconTasklistButtonPopover : Gtk.Popover {
 				controls_layout.destroy();
 			});
 
-			var class_ids = window.get_class_ids();
-			if (class_ids == null || class_ids.length == 0) {
-				warning("Window '%s' has no class IDs", window.get_name());
-				return;
+			var control = stack.get_child_by_name("controls");
+			if (control != null) {
+				stack.set_visible_child_name("main");
+				stack.remove(control);
+				control.destroy();
 			}
 
-			string id = class_ids[0];
-			stack.add_named(controls_layout, id);
-			stack.set_visible_child_name(id);
+			stack.add_named(controls_layout, "controls");
+			stack.set_visible_child_name("controls");
 		});
 
 		windows.add(window_item);
 	}
 
 	public void remove_window(Xfw.Window window) {
-		var class_ids = window.get_class_ids();
-		if (class_ids == null || class_ids.length == 0) {
-			warning("Window '%s' has no class IDs in remove_window", window.get_name());
-			return;
-		}
-
-		string window_id = class_ids[0];
 		WindowItem? window_item = null;
 
 		// Get the window item for this window, if exists
 		foreach (var child in windows.get_children()) {
-			var child_class_ids = ((WindowItem) child).window.get_class_ids();
-			if (child_class_ids != null && child_class_ids.length > 0) {
-				string child_id = child_class_ids[0];
-				if (child_id == window_id) {
-					window_item = child as WindowItem;
-					break;
-				}
+			var wnd_item = child as WindowItem;
+			if (wnd_item.window == window) {
+				window_item = wnd_item;
+				break;
 			}
 		}
 
@@ -236,19 +226,12 @@ public class IconTasklistButtonPopover : Gtk.Popover {
 
 		window_item.destroy();
 
-		string id = window_id.to_string();
-
-		// Set the stack page to the main layout if we happen to have this window's page open
-		if (stack.get_visible_child_name() == id) {
+		// If the controls-page of this window is currently open, remove it and activate the "main"-stack
+		var wnd_controls = stack.get_child_by_name("controls") as WindowControls;
+		if (wnd_controls != null && wnd_controls.window == window ) {
 			stack.set_visible_child_name("main");
-		}
-
-		// If a page for this window exists, remove it
-		var controls_layout = stack.get_child_by_name(id);
-
-		if (controls_layout != null) {
-			stack.remove(controls_layout);
-			controls_layout.destroy();
+			stack.remove(wnd_controls);
+			wnd_controls.destroy();
 		}
 	}
 }


### PR DESCRIPTION

## Description

The PR fixes #867 

---
1) Removing the correct ListView-item

Till now the items (list of open windows) in the popover were identified by the class_id (e.g. "nemo" or "code-oss"). But the class_id isn't unique per window. Because of that its not possible to find the correct unique window-entry in the list-view. All entries have the same identical class_id.

Now in the PR each listview-entry gets casted to `WindowItem`. After that the stored window-property is available and makes comparing the closing-window with the stored window in `WindowItem` possible. If it finds the correct item within the ListView, it gets removed/destroyed.

---
2) WindowControls

The `WindowControl`s are only shown if the user clicks on the arrow of a ListView-item. In that case a extra named-child gets added to the stack that will show controls like Maximize and Minimize. Till now the class_id was used as the stack-child's name. But the class_id is the same for all windows in the group, and thus it was not possible to use the class_id to identify the currently opened `WindowControl`'s window (e.g. within `remove_window`).

Because there was always only one WindowControls-pane open, the child-name within the stack was now changed to "controls". If a window of that ButtonGroup gets closed and this window's "controls"-pane is active, the stack is switched back to "main" and the active controls-pane gets destroyed.

---
Please let me know if I should improve something.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
