### PR TITLE
Ensure budgie-desktop is part of XDG_DATA_DIRS in the same way as the prior Budgie:GNOME session id

### DIFF
--- a/src/session/startbudgielabwc.in
+++ b/src/session/startbudgielabwc.in
@@ -33,6 +33,7 @@ if [ -z "${XDG_RUNTIME_DIR}" ]; then
         fi
     fi
 fi
+
 if [ ! -e "${XDG_RUNTIME_DIR}" ]; then
     logger "XDG_RUNTIME_DIR is invalid or does not exist!"
     logger "Creating XDG_RUNTIME_DIR..."
@@ -42,6 +43,17 @@ if [ ! -e "${XDG_RUNTIME_DIR}" ]; then
     }
 fi
 
+# Fix desktop file override precedence
+if [ -z "$XDG_DATA_DIRS" ]; then
+    export XDG_DATA_DIRS="@datadir@/budgie-desktop:@datadir@"
+else
+    case ":$XDG_DATA_DIRS:" in
+        *":@datadir@/budgie-desktop:"*) ;;
+        *)
+            export XDG_DATA_DIRS="@datadir@/budgie-desktop:$XDG_DATA_DIRS"
+            ;;
+    esac
+fi
 
 # freedesktop specifications mandate that the definition
 # of XDG_SESSION_TYPE should be respected


### PR DESCRIPTION
## Description
in budgie 10.9.x XDG_DATA_DIRS contained /usr/share/budgie-desktop.

With our wayland config this has been lost - so lets readd it.  This ensures things like the menu picks up /usr/share/budgie-desktop/applications before /usr/share/applications - i.e. distros can override desktop entries such as OnlyShowIn.  For example org.gnome.PowerStats.desktop is defined under Debian as GNOME;Unity and thus is never visible in Budgie.  By placing the equivalent .desktop in /usr/share/budgie-desktop/applications with a OnlyShowIn=Budgie; then it will appear.  It means therefore we don't have to start chasing various package managers to get Budgie included.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
