### PR TITLE
Refresh appindexer correctly in seconds rather than milliseconds

### DIFF
--- a/src/appindexer/AppIndex.vala
+++ b/src/appindexer/AppIndex.vala
@@ -109,7 +109,7 @@ namespace Budgie {
 			}
 
 			// Update the application system after the timeout
-			this.timeout_id = Timeout.add(seconds, () => {
+			this.timeout_id = Timeout.add_seconds(seconds, () => {
 				this.refresh();
 				this.timeout_id = 0;
 				return Source.REMOVE;


### PR DESCRIPTION
## Description
As the title says - the appindexer needs time in seconds to refresh when application changes are made.
The code assumes seconds - but we were using the vala Timeout which is in milliseconds.  Thus applications in the menu
would get confused if new or removed apps are done.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
