### PR TITLE
fix(dialogs): make the run and power dialogs behave with sloppy/mouse focus

### DIFF
--- a/src/dialogs/power/meson.build
+++ b/src/dialogs/power/meson.build
@@ -10,6 +10,7 @@ powerdialog_sources = [
 powerdialog_deps = [
     dep_giounix,
     dep_gtk3,
+    dep_gtk_layer_shell,
     link_libconfig,
     link_libtheme
 ]


### PR DESCRIPTION
## Description
run and power dialogs hide themselves as soon as the focus changes with sloppy and mouse.

This PR works around this - basically recognise if those methods are being used and instead wait until
the user is over the dialogs before then deciding whether to hide the dialog if the user moves outside.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
