### PR TITLE
Remove specific compiler standards version - default is now a distro matter - closes #883

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,10 +6,6 @@ project(
         'GPL-2.0',
         'LGPL-2.1',
     ],
-    default_options: [
-        'c_std=c11',
-        'warning_level=3'
-    ],
 )
 
 # Vala generates bad C code and missing these on gcc 14 will cause FTBFS


### PR DESCRIPTION
## Description
No need to specify the C standard to compile against.  This should be a distro matter

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
