### PR TITLE
docs: add contributing guidelines, AI policy, DCO, and agent docs

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: commit
+description: Stage and commit changes using Conventional Commits
+disable-model-invocation: false
+allowed-tools: Bash(git *)
+---
+
+Create a git commit for the current changes following the Conventional Commits specification.
+
+## Steps
+
+1. Run these commands in parallel to understand the current state:
+   - `git status` to see all changed and untracked files
+   - `git diff` to see unstaged changes
+   - `git diff --cached` to see already-staged changes
+   - `git log --oneline -5` to see recent commit style
+
+2. Analyze the changes and determine:
+   - Which files should be staged (skip files that likely contain secrets like `.env`, credentials, etc.)
+   - The appropriate Conventional Commit type and scope
+   - A concise description of the change
+
+3. Stage the relevant files by name (do NOT use `git add -A` or `git add .`)
+
+4. Determine attribution — analyze the conversation context:
+   - **Did Claude write or modify code** (generate implementations, refactor logic, write new functions)? → Add `Assisted-by: Claude:<model-id>` trailer
+   - **Did Claude only perform mechanical tasks** (committing, formatting, running commands) or did the human make all code changes? → NO trailer
+   - Never use `Co-Authored-By`
+
+5. Craft the commit message following this format:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[Assisted-by: Claude:<model-id> — only if Claude assisted with code changes]
+Signed-off-by: <name> <email>
+```
+
+**Important**: All commits require a DCO sign-off. Always use `git commit -s` to automatically add the `Signed-off-by` trailer.
+
+### Conventional Commit types and scopes
+
+See [CONTRIBUTING.md](../../../CONTRIBUTING.md#conventional-commits) for the full list of types and scopes.
+
+### Rules
+
+- The description should be lowercase, imperative mood, and not end with a period
+- Keep the first line under 72 characters
+- Scope is optional but encouraged — use the most relevant area
+- The body should explain **why**, not what — the diff shows what changed
+- If changes span multiple concerns, prefer a single commit with a clear summary over being overly granular
+- Always pass the commit message via a HEREDOC:
+
+```bash
+git commit -s -m "$(cat <<'EOF'
+type(scope): description
+
+Optional body.
+
+Assisted-by: Claude:<model-id>
+EOF
+)"
+```
+
+6. After committing, run `git status` to verify success.
+
+## Arguments
+
+If `$ARGUMENTS` is provided, use it as guidance for the commit message or scope.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: pr
+description: Create a pull request for the current branch
+disable-model-invocation: false
+allowed-tools: Bash(git *), Bash(gh pr create *), Skill(commit)
+---
+
+# Create a Pull Request
+
+You are creating a pull request for the current branch on budgie-desktop (C / Vala desktop environment built with Meson + Ninja).
+
+## Step 1: Gather Context
+
+Run these commands to understand the current state:
+
+```bash
+git status
+git log --oneline main..HEAD
+git diff main...HEAD --stat
+git diff main...HEAD
+git branch --show-current
+```
+
+If there are uncommitted changes, run the `/commit` skill first before proceeding.
+
+## Step 2: Determine PR Type
+
+Based on the changes, choose the appropriate conventional commit type and scope. See [CONTRIBUTING.md](../../CONTRIBUTING.md#conventional-commits) for the full list of types and scopes.
+
+## Step 3: Generate PR Content
+
+**Title format**: `<type>: <short description>` (under 70 characters)
+
+Read [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) and use its structure as the body format for the PR. Fill in the sections based on the changes being submitted.
+
+## Step 4: Create the PR
+
+Push the branch and create the PR:
+
+```bash
+git push -u origin HEAD
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+<body content>
+EOF
+)"
+```
+
+**Target branch**: `main` (default)
+
+## Notes
+
+- Review all commits since divergence from main, not just the latest one
+- Ensure the title accurately reflects the overall change
+- Test plan should include build verification with `ninja -C build`
+- See [CONTRIBUTING.md](../../CONTRIBUTING.md) for full contribution guidelines and AI attribution policy

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,16 @@
 ## Description
-<Info on what this pull request adds>
 
+<!-- What changed and why? -->
+
+## Test plan
+
+<!-- How did you verify the changes? -->
 
 ### Submitter Checklist
 
+- [ ] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
 - [ ] Squashed commits with `git rebase -i` (if needed)
 - [ ] Built budgie-desktop and verified that the patch worked (if needed)
+- [ ] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable
+
+<!-- Supplemental comments on the PR with AI prompt/planning information are welcome and encouraged for research and learnings, but not mandatory. Share them as PR comments, not committed to the repository. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+# Budgie Desktop — AI Agent Documentation
+
+This document provides technical context for AI coding assistants working on Budgie Desktop. For contribution practices, see the [Contributing](https://docs.buddiesofbudgie.org/developer/contributing) documentation. For AI usage guidelines, see the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy).
+
+## Project Identity
+
+- **Project**: Budgie Desktop 10.10
+- **Type**: Wayland-only desktop environment
+- **Languages**: C and Vala
+- **Build system**: Meson + Ninja
+- **UI toolkit**: GTK 3.24+
+
+## Build Quick Reference
+
+```bash
+# Configure
+meson build --prefix=/usr --sysconfdir=/etc
+
+# Build
+ninja -j$(nproc) -C build
+
+# Install
+sudo ninja install -C build
+```
+
+### Meson Options
+
+See [`meson_options.txt`](meson_options.txt) for available build options.
+
+For full dependency lists and distro-specific packages, see the [build documentation](https://docs.buddiesofbudgie.org/10.10/developer/workflow/building-budgie-desktop/).
+
+## Repository Structure
+
+### Source Directories (`src/`)
+
+| Directory | Purpose | Commit Scope |
+|-----------|---------|--------------|
+| `src/panel/` | Panel framework and core | `panel` |
+| `src/panel/applets/` | Panel applets (see below) | `panel/applets` or `<applet-name>` |
+| `src/raven/` | Notification/widget sidebar | `raven` |
+| `src/raven/widgets/` | Raven widgets (see below) | `raven/widgets` or `<widget-name>` |
+| `src/daemon/` | Background daemon | `daemon` |
+| `src/wm/` | Window management | `wm` |
+| `src/session/` | Session management | `session` |
+| `src/libsession/` | Session library | `session` |
+| `src/theme/` | Theming engine | `theme` |
+| `src/windowing/` | Windowing abstractions | `windowing` |
+| `src/appindexer/` | Application indexing | `appindexer` |
+| `src/dialogs/` | Dialogs (polkit, power, run, screenshot, sendto) | `dialogs` |
+| `src/lib/` | Shared library | `lib` |
+| `src/config/` | Configuration | `config` |
+| `src/bridges/` | Bridge interfaces | `bridges` |
+| `src/appsys/` | Application system | `appsys` |
+| `src/plugin/` | Plugin system | `plugin` |
+
+### Panel Applets (`src/panel/applets/`)
+
+budgie-menu, caffeine, clock, icon-tasklist, keyboard-layout, lock-keys, night-light, notifications, places-indicator, raven-trigger, separator, show-desktop, spacer, status, tasklist, trash, tray, user-indicator, workspaces
+
+### Raven Widgets (`src/raven/widgets/`)
+
+calendar, media-controls, sound-input, sound-output, usage-monitor
+
+### Other Key Directories
+
+| Directory | Purpose | Commit Scope |
+|-----------|---------|--------------|
+| `data/` | Data files, schemas, desktop entries | `data` |
+| `docs/` | Documentation, man pages | `docs` |
+| `po/` | Translations | `i18n` |
+| `vapi/` | Vala API bindings | `vapi` |
+| `subprojects/` | Git submodules | varies |
+
+## Wayland Context
+
+Budgie 10.10 is **Wayland-only** and uses [labwc](https://labwc.github.io/) as its compositor.
+
+### Required Protocols
+
+- `ext-workspace-v1` — Workspace management
+- `wlr-foreign-toplevel-management` — Toplevel window tracking
+- `wlr-layer-shell` — Layer surfaces (panels, overlays)
+- `wlr-output-management` — Output/display configuration
+- `xdg-output` — Logical output information
+
+### Positioning
+
+Uses [gtk-layer-shell](https://github.com/wmww/gtk-layer-shell) for panel and overlay positioning on Wayland.
+
+## Fetching External Resources
+
+Agents should web fetch these resources when relevant to the task:
+
+- **Build docs**: https://docs.buddiesofbudgie.org/10.10/developer/workflow/building-budgie-desktop/ — for dependency lists and distro-specific setup
+- **Contributing**: https://docs.buddiesofbudgie.org/developer/contributing — for DCO, sign-off, and contribution requirements
+- **AI Policy**: https://docs.buddiesofbudgie.org/organization/ai-policy — for attribution requirements and AI usage guidelines
+- **GTK 3 API reference**: https://docs.gtk.org/gtk3/ — for UI widget and API questions
+- **Vala language reference**: https://vala.dev/tutorials/programming-language/main/ — for language-specific syntax and patterns
+
+## Attribution and Sign-off
+
+All commits must include a `Signed-off-by` trailer. Use `git commit -s` to add it automatically.
+
+When committing, the agent must analyze the conversation context to determine whether it actually assisted with code changes (writing, modifying, or generating code). If so, add an `Assisted-by` trailer. Mechanical tasks (committing, formatting, running commands) do not constitute code assistance and do not require the trailer. Fetch the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) for full attribution guidance.
+
+## Code Conventions
+
+- Follow existing patterns in the codebase
+- **Vala naming**: PascalCase for classes and interfaces, snake_case for methods and variables
+- **C naming**: `budgie_` prefix for public API functions
+- Refer to surrounding code in the same file/module for style guidance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,25 +33,25 @@ For full dependency lists and distro-specific packages, see the [build documenta
 
 ### Source Directories (`src/`)
 
-| Directory | Purpose | Commit Scope |
-|-----------|---------|--------------|
-| `src/panel/` | Panel framework and core | `panel` |
-| `src/panel/applets/` | Panel applets (see below) | `panel/applets` or `<applet-name>` |
-| `src/raven/` | Notification/widget sidebar | `raven` |
-| `src/raven/widgets/` | Raven widgets (see below) | `raven/widgets` or `<widget-name>` |
-| `src/daemon/` | Background daemon | `daemon` |
-| `src/wm/` | Window management | `wm` |
-| `src/session/` | Session management | `session` |
-| `src/libsession/` | Session library | `session` |
-| `src/theme/` | Theming engine | `theme` |
-| `src/windowing/` | Windowing abstractions | `windowing` |
-| `src/appindexer/` | Application indexing | `appindexer` |
-| `src/dialogs/` | Dialogs (polkit, power, run, screenshot, sendto) | `dialogs` |
-| `src/lib/` | Shared library | `lib` |
-| `src/config/` | Configuration | `config` |
-| `src/bridges/` | Bridge interfaces | `bridges` |
-| `src/appsys/` | Application system | `appsys` |
-| `src/plugin/` | Plugin system | `plugin` |
+| Directory            | Purpose                                          | Commit Scope                       |
+| -------------------- | ------------------------------------------------ | ---------------------------------- |
+| `src/panel/`         | Panel framework and core                         | `panel`                            |
+| `src/panel/applets/` | Panel applets (see below)                        | `panel/applets` or `<applet-name>` |
+| `src/raven/`         | Notification/widget sidebar                      | `raven`                            |
+| `src/raven/widgets/` | Raven widgets (see below)                        | `raven/widgets` or `<widget-name>` |
+| `src/daemon/`        | Background daemon                                | `daemon`                           |
+| `src/wm/`            | Window management                                | `wm`                               |
+| `src/session/`       | Session management                               | `session`                          |
+| `src/libsession/`    | Session library                                  | `session`                          |
+| `src/theme/`         | Theming engine                                   | `theme`                            |
+| `src/windowing/`     | Windowing abstractions                           | `windowing`                        |
+| `src/appindexer/`    | Application indexing                             | `appindexer`                       |
+| `src/dialogs/`       | Dialogs (polkit, power, run, screenshot, sendto) | `dialogs`                          |
+| `src/lib/`           | Shared library                                   | `lib`                              |
+| `src/config/`        | Configuration                                    | `config`                           |
+| `src/bridges/`       | Bridge interfaces                                | `bridges`                          |
+| `src/appsys/`        | Application system                               | `appsys`                           |
+| `src/plugin/`        | Plugin system                                    | `plugin`                           |
 
 ### Panel Applets (`src/panel/applets/`)
 
@@ -63,13 +63,13 @@ calendar, media-controls, sound-input, sound-output, usage-monitor
 
 ### Other Key Directories
 
-| Directory | Purpose | Commit Scope |
-|-----------|---------|--------------|
-| `data/` | Data files, schemas, desktop entries | `data` |
-| `docs/` | Documentation, man pages | `docs` |
-| `po/` | Translations | `i18n` |
-| `vapi/` | Vala API bindings | `vapi` |
-| `subprojects/` | Git submodules | varies |
+| Directory      | Purpose                              | Commit Scope |
+| -------------- | ------------------------------------ | ------------ |
+| `data/`        | Data files, schemas, desktop entries | `data`       |
+| `docs/`        | Documentation, man pages             | `docs`       |
+| `po/`          | Translations                         | `i18n`       |
+| `vapi/`        | Vala API bindings                    | `vapi`       |
+| `subprojects/` | Git submodules                       | varies       |
 
 ## Wayland Context
 
@@ -95,7 +95,6 @@ Agents should web fetch these resources when relevant to the task:
 - **Contributing**: https://docs.buddiesofbudgie.org/developer/contributing — for DCO, sign-off, and contribution requirements
 - **AI Policy**: https://docs.buddiesofbudgie.org/organization/ai-policy — for attribution requirements and AI usage guidelines
 - **GTK 3 API reference**: https://docs.gtk.org/gtk3/ — for UI widget and API questions
-- **Vala language reference**: https://vala.dev/tutorials/programming-language/main/ — for language-specific syntax and patterns
 
 ## Attribution and Sign-off
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Budgie Desktop — Claude Code Configuration
+
+See [AGENTS.md](AGENTS.md) for full agent documentation.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development practices and AI policy.
+
+## Quick Reference
+
+- Project: Budgie Desktop 10.10
+- Languages: C, Vala
+- Build: `meson build --prefix=/usr --sysconfdir=/etc && ninja -C build`
+- Full build docs: https://docs.buddiesofbudgie.org/10.10/developer/workflow/building-budgie-desktop/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing to Budgie Desktop
+
+<!-- This document is written for both human contributors and AI coding assistants. -->
+
+All contributors are expected to follow the practices outlined in our [Contributing](https://docs.buddiesofbudgie.org/developer/contributing) documentation. If AI tools or LLMs were used, review our [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) before submitting.
+
+## Getting Started
+
+### Build Quick Reference
+
+```bash
+# Clone
+git clone https://github.com/BuddiesOfBudgie/budgie-desktop.git && cd budgie-desktop && git submodule update --init
+
+# Configure (generic)
+meson build --prefix=/usr --sysconfdir=/etc
+# Configure (Arch)
+meson setup build --prefix=/usr --sysconfdir=/etc --libexecdir=/usr/lib
+# Configure (Debian / Ubuntu)
+meson build --prefix=/usr --libdir=/usr/lib
+# Configure (Fedora)
+meson build --prefix=/usr --sysconfdir=/etc --libexecdir=/usr/libexec
+# Configure (Solus)
+meson build --prefix=/usr --libdir=/usr/lib64 --sysconfdir=/etc -Dwith-stateless=true --buildtype plain
+
+# Build
+ninja -j$(nproc) -C build
+
+# Install
+sudo ninja install -C build
+```
+
+For full dependency lists and distro-specific packages, see the [build documentation](https://docs.buddiesofbudgie.org/10.10/developer/workflow/building-budgie-desktop/).
+
+## Developer Certificate of Origin (DCO)
+
+All commits must be signed off under the [Developer Certificate of Origin](https://developercertificate.org/) using `git commit -s`. See [DCO.txt](DCO.txt) for the full text and the [Contributing](https://docs.buddiesofbudgie.org/developer/contributing) documentation for details.
+
+## Conventional Commits
+
+All commits must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+
+### Format
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional trailers]
+```
+
+### Types
+
+| Type    | Purpose                                        |
+| ------- | ---------------------------------------------- |
+| `feat`  | A new feature or capability                    |
+| `fix`   | A bug fix                                      |
+| `docs`  | Documentation only changes                     |
+| `chore` | Maintenance tasks, dependency updates, tooling |
+| `ci`    | CI/CD configuration changes                    |
+| `build` | Build system or external dependency changes    |
+
+### Scopes
+
+Use the most specific scope that fits. For example, use `panel` for panel core changes, `panel/applets` for general applet work, and `icon-tasklist` for a specific applet.
+
+| Scope           | Directory / Area                                                                     |
+| --------------- | ------------------------------------------------------------------------------------ |
+| `panel`         | `src/panel/` — Panel framework and core                                              |
+| `raven`         | `src/raven/` — Notification/widget sidebar                                           |
+| `daemon`        | `src/daemon/` — Background daemon                                                    |
+| `session`       | `src/session/`, `src/libsession/` — Session management                               |
+| `theme`         | `src/theme/` — Theming engine                                                        |
+| `windowing`     | `src/windowing/` — Windowing abstractions                                            |
+| `appindexer`    | `src/appindexer/` — Application indexing                                             |
+| `lib`           | `src/lib/` — Shared library                                                          |
+| `<dialog-name>` | `src/dialog/<dialog-name>` — Changes to specific dialogs                             |
+| `panel/applets` | `src/panel/applets/` — General panel applet changes                                  |
+| `<applet-name>` | `src/panel/applets/<name>/` — Specific applet (e.g., `icon-tasklist`, `budgie-menu`) |
+| `raven/widgets` | `src/raven/widgets/` — General Raven widget changes                                  |
+| `<widget-name>` | `src/raven/widgets/<name>/` — Specific widget (e.g., `calendar`, `media-controls`)   |
+| `config`        | `src/config/` — Configuration                                                        |
+| `bridges`       | `src/bridges/` — Bridge interfaces                                                   |
+| `data`          | `data/` — Data files, schemas, desktop entries                                       |
+| `docs`          | `docs/` — Documentation, man pages                                                   |
+| `build`         | `meson.build`, `meson_options.txt` — Build system                                    |
+| `ci`            | `.github/` — CI/CD workflows                                                         |
+
+### Rules
+
+- Description: lowercase, imperative mood (write as a command, e.g., "add feature" not "added feature" or "adds feature"), no trailing period
+- Keep the first line under 72 characters
+- The body should explain **why**, not what — the diff shows what changed
+
+## AI Policy
+
+Contributors may use AI tools (Claude, Gemini, Copilot, ChatGPT, etc.) as part of their workflow. If you have used AI tools or LLMs as part of your contribution, you are expected to have read and understood the full [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) before submitting. The key rules:
+
+- All contributions must be tested before submission
+- Non-trivial AI-assisted code must be built, installed, and tested by the contributor
+- All commits must be signed off under the [DCO](DCO.txt) using `git commit -s`
+- Use `Assisted-by: <Tool>:<model-id>` commit trailers when AI wrote, generated, or substantially modified code
+- Using AI for research only (human wrote all code) does not require attribution
+- Intentional obfuscation of AI tooling usage is grounds for rejection and may result in being blocked from future contributions
+
+For detailed attribution guidance and examples, see the full [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy).
+
+## Pull Requests
+
+- Provide a clear description explaining **what** changed and **why**
+- Include a test plan describing how you verified the changes
+- See the [pull request template](.github/PULL_REQUEST_TEMPLATE.md) for the expected format
+- If AI tools were used for code changes, ensure commits include the appropriate `Assisted-by` trailer
+- Supplemental comments on the PR with AI prompt/planning information are welcome and encouraged for research and learnings, but not mandatory. These should be shared as PR comments, not committed to the repository.

--- a/DCO.txt
+++ b/DCO.txt
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
## Description

Add human-centric development documentation for budgie-desktop:

- `CONTRIBUTING.md` with build quick reference (distro-specific), conventional commit types/scopes, DCO requirements, AI policy summary, and PR expectations
- `AGENTS.md` with technical context for AI coding assistants (project identity, repo structure, Wayland context, external resources, attribution rules, code conventions)
- `CLAUDE.md` as thin pointer to AGENTS.md and CONTRIBUTING.md
- `DCO.txt` with Developer Certificate of Origin v1.1
- Updated PR template with test plan section, DCO sign-off checklist, and AI policy checklist
- Added `/commit` and `/pr` Claude Code skills with budgie-specific configuration

Full AI policy and contributing docs live on the docs site — this PR references them rather than duplicating:
- https://docs.buddiesofbudgie.org/organization/ai-policy
- https://docs.buddiesofbudgie.org/developer/contributing

## Test plan

- [x] All cross-reference links resolve correctly

### Submitter Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
- [x] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable