### PR TITLE
build: Fix missing dep for pkgconfig and GIR

### DIFF
--- a/src/plugin/panel/meson.build
+++ b/src/plugin/panel/meson.build
@@ -76,6 +76,7 @@ libpanelplugin_gir = gnome.generate_gir(
         'Gio-2.0',
         'Gtk-3.0',
         'Peas-2',
+        'GtkLayerShell-0.1',
     ],
     symbol_prefix: 'budgie',
     identifier_prefix: 'Budgie',
@@ -108,10 +109,11 @@ pkgconfig.generate(
     subdirs: 'budgie-desktop',
     libraries: ['-L${libdir}', '-lbudgie-plugin'],
     requires: [
-        'gtk+-3.0 >= 3.24.0',
-        'libpeas-2 >= 1.99.0',
-        'glib-2.0 >= 2.46.0',
         'gio-unix-2.0 >= 2.46.0',
+        'glib-2.0 >= 2.46.0',
+        'gtk+-3.0 >= 3.24.0',
+        'gtk-layer-shell-0 >= 0.9.0',
+        'libpeas-2 >= 1.99.0',
     ],
 )
 


### PR DESCRIPTION
## Description

Fixes GtkLayerShell being missing from the dependency list when generating the GIR and pkgconfig files for panel plugin.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
