### PR TITLE
tasklist: Fix workspace change always hide buttons

### DIFF
--- a/src/panel/applets/tasklist/TasklistApplet.vala
+++ b/src/panel/applets/tasklist/TasklistApplet.vala
@@ -479,9 +479,13 @@ public class TasklistApplet : Budgie.Applet {
 		var button = get_button_for_window(window);
 		if (button == null) return;
 
-		if (window.workspace.get_state() == Xfw.WorkspaceState.ACTIVE) {
-			button.show();
+		var workspace = window.get_workspace();
+
+		if (workspace == null) return;
+
+		if ((window.workspace.get_state() & Xfw.WorkspaceState.ACTIVE) != 0) {
 			button.set_no_show_all(false);
+			button.show();
 		} else {
 			button.hide();
 			button.set_no_show_all(true); // make sure we don't randomly show buttons not belonging to the current workspace


### PR DESCRIPTION
## Description

Window-to-workspace association doesn't yet work with the current ecosystem. Therefore, only try to do workspace operations if we actually have a workspace attached to the window. I'm not actually sure how this didn't just segfault before.

Fixes https://github.com/BuddiesOfBudgie/budgie-desktop/issues/904

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
