### PR TITLE
Add a brief delay to allow workspace spinner to complete - closes #903

### DIFF
--- a/src/bridges/labwc/labwc_bridge.py
+++ b/src/bridges/labwc/labwc_bridge.py
@@ -1348,6 +1348,8 @@ class Bridge:
             updated = True
 
         if updated:
+            import time
+            time.sleep(0.5)
             self.write_config()
 
     # all gnome desktop interface gsettings changes are managed

--- a/src/bridges/labwc/labwc_bridge.py
+++ b/src/bridges/labwc/labwc_bridge.py
@@ -21,6 +21,7 @@ import gettext
 from enum import StrEnum
 import dbus
 import dbus.mainloop.glib
+import time
 
 import gi
 from gi.repository import Gio, GLib
@@ -1342,6 +1343,7 @@ class Bridge:
             updated = True
 
         if updated:
+            time.sleep(0.5)
             self.write_config()
 
     # all gnome desktop interface gsettings changes are managed

--- a/src/panel/settings/settings_desktop.vala
+++ b/src/panel/settings/settings_desktop.vala
@@ -127,22 +127,10 @@ namespace Budgie {
 
 		// build_workspace_option will build the workspace option for the settings
 		private void build_workspace_option() {
-			workspace_count = new Gtk.SpinButton.with_range(1, 8, 1); // Create our button, with a minimum of 1 workspace and max of 8
+			workspace_count = new Gtk.SpinButton.with_range(1.0, 8.0, 1.0); // Create our button, with a minimum of 1 workspace and max of 8
 			workspace_count.set_value((double) gnome_wm_settings.get_int("num-workspaces")); // Set our default value
 
-			workspace_count.value_changed.connect(() => { // On value change
-				int new_val = workspace_count.get_value_as_int(); // Get the value as an int
-
-				if (new_val < 1) { // Ensure valid minimum
-					new_val = 1;
-					workspace_count.set_value(1.0); // Set as 1
-				} else if (new_val > 8) { // Ensure valid maximum
-					new_val = 8;
-					workspace_count.set_value(8.0); // Set as 8
-				}
-
-				gnome_wm_settings.set_int("num-workspaces", new_val); // Update num-workspaces
-			});
+			gnome_wm_settings.bind("num-workspaces", workspace_count, "value", SettingsBindFlags.DEFAULT);
 
 			grid.add_row(new SettingsRow(workspace_count,
 				_("Number of virtual desktops"),


### PR DESCRIPTION
## Description
Tidy up so odd code dealing with workspace changes in BDS.
Added a small delay to ensure that the button click on the Gtk Adjustment widget completes before calling labwc -r

Tested by repeatedly clicking the +- buttons faster than the 0.5 second delay and the workspaces correctly sorted themselves out.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-desktop and verified that the patch worked (if needed)
