### PR TITLE
ci: add DCO app configuration

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,3 @@
+# https://github.com/dcoapp/app
+allowRemediationCommits:
+  individual: true


### PR DESCRIPTION
## Description

Set up DCO (Developer Certificate of Origin) config to allow for remediation commits by individuals.

## Test plan

No testing has been done yet, awaiting this pull request to trigger GHA before I can configure DCO per [required statuses](https://github.com/dcoapp/app/blob/main/docs/required-statuses.md) document.

### Submitter Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
- [x] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable

<!-- Supplemental comments on the PR with AI prompt/planning information are welcome and encouraged for research and learnings, but not mandatory. Share them as PR comments, not committed to the repository. -->
