### PR TITLE
Use static module variable for wayland client to stop freezes

### DIFF
--- a/src/dialogs/polkit/polkitdialog.vala
+++ b/src/dialogs/polkit/polkitdialog.vala
@@ -10,6 +10,7 @@
  */
 
 namespace Budgie {
+	static WaylandClient? wayland_client = null;
 	[GtkTemplate (ui="/com/solus-project/budgie/polkit/dialog.ui")]
 	public class AgentDialog : Gtk.Window {
 		[GtkChild]
@@ -154,23 +155,25 @@ namespace Budgie {
 			GtkLayerShell.set_anchor(this, GtkLayerShell.Edge.TOP, false);
 			GtkLayerShell.set_keyboard_mode(this, GtkLayerShell.KeyboardMode.ON_DEMAND);
 
-			var wayland_client = new WaylandClient();
+			if (wayland_client == null) {
+				wayland_client = new WaylandClient();
 
-			if (!wayland_client.is_initialised()) {
-				warning("WaylandClient not initialized for polkit dialog");
-				// Fallback: just init the window without positioning
-			} else {
-				// Safe initialization with monitor
-				wayland_client.with_valid_monitor(() => {
-					var monitor = wayland_client.gdk_monitor;
-					if (monitor == null) {
-						warning("Failed to get monitor for polkit dialog");
-						return false;
-					}
+				if (!wayland_client.is_initialised()) {
+					warning("WaylandClient not initialized for polkit dialog");
+					// Fallback: just init the window without positioning
+				} else {
+					// Safe initialization with monitor
+					wayland_client.with_valid_monitor(() => {
+						var monitor = wayland_client.gdk_monitor;
+						if (monitor == null) {
+							warning("Failed to get monitor for polkit dialog");
+							return false;
+						}
 
-					GtkLayerShell.set_monitor(this, monitor);
-					return true;
-				});
+						GtkLayerShell.set_monitor(this, monitor);
+						return true;
+					});
+				}
 			}
 
 			key_release_event.connect(on_key_release);


### PR DESCRIPTION
## Description

This PR resolves a continuing issue with budgie-polkit-dialog where is can and does occasionally spin to 100% and polkit dialogs and popups like logout, shutdown and reboot no longer appears.

The issue is due to libxfce4windowing invoking  wayland client requests that seemingly lock each other out I.e. dont allow each to run to completion.

This PR ensures only one reference to wayland client (our wrapper around lfw) and thus requests to this dialog reference are guaranteed to be a singular rather than depending on internal lfw references cleaning themselves up when the dialog was previously releasing its reference 

## Test plan

Use gnome-disks where i can repeatedly reproduce this when writing isos to usb drives. I.e. polkit should be invoked.

### Submitter Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
- [ ] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable
