### PR TITLE
build: Add option to set xdp libexecdir

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,6 @@
 option('ci', type: 'boolean', value: false, description: 'Continuous Integration flag (internal use only)')
 option('gsd-libexecdir', type: 'string', description: 'Directory containing the gsd-* executables')
+option('xdp-libexecdir', type: 'string', description: 'Directory containing the xdg-desktop-portal-* executables')
 option('labwc-bindir', type: 'string', description: 'Directory containing the labwc executable')
 #option('magpie-bindir', type: 'string', description: 'Directory containing the magpie-wm executable')
 option('use-old-zenity', type: 'boolean', value: false, description: 'Use old zenity CLI API for out-of-process dialog handling')

--- a/src/session/budgie-desktop.in
+++ b/src/session/budgie-desktop.in
@@ -19,6 +19,6 @@ export BUDGIE_SESSION_VERSION=${BUDGIE_VERSION}
 compositor="@gsd_libexecdir@/budgie-session-compositor-ready"
 if command -v "$compositor" > /dev/null 2>&1 && "$compositor"; then
   @bindir@/org.buddiesofbudgie.Services &
-  @libexecdirroot@/xdg-desktop-portal &
+  @xdp_libexecdir@/xdg-desktop-portal &
   exec budgie-session --builtin --session=org.buddiesofbudgie.BudgieDesktop $*
 fi

--- a/src/session/meson.build
+++ b/src/session/meson.build
@@ -68,6 +68,13 @@ if gsd_libexecdir == ''
 endif
 session_data.set('gsd_libexecdir', gsd_libexecdir)
 
+# Set the libexecdir for xdg-desktop-portal
+xdp_libexecdir = get_option('xdp-libexecdir')
+if xdp_libexecdir == ''
+    xdp_libexecdir = join_paths(libexecdirroot)
+endif
+session_data.set('xdp_libexecdir', xdp_libexecdir)
+
 # Write the budgie-desktop.session.in file from the .in.in
 session_conf = configure_file(
     input: 'budgie-desktop.session.in.in',


### PR DESCRIPTION
## Description

On Solus, we set a package's libexecdir to `lib64/${package}` or `lib32/${package}`, which has the side effect of some of our build variables being incorrect. This option enables us to set the libexecdir for xdg-desktop-portal manually, thus avoiding the issue.

## Test plan

Rebuild the Solus 10.10 testing package with the new option, and verify that the xdp path in `/usr/bin/budgie-desktop` is correct.

### Submitter Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
- [ ] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable
