### PR TITLE
Add labwc raiseOnFocusDelay for the focus-mode - closes #750

### DIFF
--- a/src/bridges/labwc/labwc_bridge.py
+++ b/src/bridges/labwc/labwc_bridge.py
@@ -1148,6 +1148,7 @@ class Bridge:
         self.desktop_wm_preferences_changed(self.desktop_wm_preferences_settings, "titlebar-font")
         self.desktop_wm_preferences_changed(self.desktop_wm_preferences_settings, "button-layout")
         self.desktop_wm_preferences_changed(self.desktop_wm_preferences_settings, "num-workspaces")
+        self.desktop_wm_preferences_changed(self.desktop_wm_preferences_settings, "auto-raise-delay")
         self.desktop_interface_changed(self.desktop_interface_settings, "gtk-theme")
         self.desktop_interface_changed(self.desktop_interface_settings, "icon-theme")
         self.desktop_interface_changed(self.desktop_interface_settings, "cursor-theme")
@@ -1193,6 +1194,55 @@ class Bridge:
         self.delay_config_write = False
         self.write_config()
 
+    def _process_focus_mode(self):
+        root = self.et.getroot()
+
+        path = "./focus/followMouse"
+        bridge = root.find(path)
+
+        if bridge == None:
+            return False
+
+        class Mode(StrEnum):
+            CLICK = 'click'
+            SLOPPY = 'sloppy'
+            MOUSE = 'mouse'
+
+        focus_mode = self.budgie_wm_settings["window-focus-mode"]
+
+        if focus_mode != Mode.CLICK:
+            bridge.text = "yes"
+        else:
+            bridge.text = "no"
+
+        pathraise = "./focus/raiseOnFocus"
+        bridgeraise = root.find(pathraise)
+
+        if bridgeraise == None:
+            return False
+
+        if focus_mode == Mode.MOUSE:
+            bridgeraise.text = "yes"
+        else:
+            bridgeraise.text = "no"
+
+        auto_raise_delay = self.desktop_wm_preferences_settings["auto-raise-delay"]
+
+        pathraisedelay = "./focus/raiseOnFocusDelay"
+        bridgeraisedelay = root.find(pathraisedelay)
+
+        if bridgeraisedelay == None:
+            focus = "./focus"
+            bridgeraisedelay = root.find(focus)
+            new_key = Et.Element("raiseOnFocusDelay")
+            bridgeraisedelay.append(new_key)
+
+            bridgeraisedelay = root.find(pathraisedelay)
+
+        bridgeraisedelay.text = str(auto_raise_delay)
+
+        return True
+
     # all solus-project budgie-wm gsettings changes are managed
     def budgie_wm_changed(self, settings, key):
         root = self.et.getroot()
@@ -1200,36 +1250,8 @@ class Bridge:
         updated = False
 
         if key == "window-focus-mode":
-            path = "./focus/followMouse"
-            bridge = root.find(path)
-
-            if bridge == None:
-                return
-
-            class Mode(StrEnum):
-                CLICK = 'click'
-                SLOPPY = 'sloppy'
-                MOUSE = 'mouse'
-
-            focus_mode = settings[key]
-
-            if focus_mode != Mode.CLICK:
-                bridge.text = "yes"
-            else:
-                bridge.text = "no"
-
-            updated = True
-
-            pathraise = "./focus/raiseOnFocus"
-            bridgeraise = root.find(pathraise)
-
-            if bridgeraise == None:
-                return
-
-            if focus_mode == Mode.MOUSE:
-                bridgeraise.text = "yes"
-            else:
-                bridgeraise.text = "no"
+            if self._process_focus_mode():
+                updated = True
 
         if key == "show-all-windows-tabswitcher":
             path = "./windowSwitcher"
@@ -1341,6 +1363,10 @@ class Bridge:
             bridge.attrib["number"] = str(settings[key])
 
             updated = True
+
+        if key == "auto-raise-delay":
+            if self._process_focus_mode():
+                updated = True
 
         if updated:
             time.sleep(0.5)

--- a/src/bridges/labwc/labwc_bridge.py
+++ b/src/bridges/labwc/labwc_bridge.py
@@ -1147,6 +1147,7 @@ class Bridge:
         self.desktop_wm_preferences_changed(self.desktop_wm_preferences_settings, "titlebar-font")
         self.desktop_wm_preferences_changed(self.desktop_wm_preferences_settings, "button-layout")
         self.desktop_wm_preferences_changed(self.desktop_wm_preferences_settings, "num-workspaces")
+        self.desktop_wm_preferences_changed(self.desktop_wm_preferences_settings, "auto-raise-delay")
         self.desktop_interface_changed(self.desktop_interface_settings, "gtk-theme")
         self.desktop_interface_changed(self.desktop_interface_settings, "icon-theme")
         self.desktop_interface_changed(self.desktop_interface_settings, "cursor-theme")
@@ -1192,6 +1193,55 @@ class Bridge:
         self.delay_config_write = False
         self.write_config()
 
+    def _process_focus_mode(self):
+        root = self.et.getroot()
+
+        path = "./focus/followMouse"
+        bridge = root.find(path)
+
+        if bridge == None:
+            return False
+
+        class Mode(StrEnum):
+            CLICK = 'click'
+            SLOPPY = 'sloppy'
+            MOUSE = 'mouse'
+
+        focus_mode = self.budgie_wm_settings["window-focus-mode"]
+
+        if focus_mode != Mode.CLICK:
+            bridge.text = "yes"
+        else:
+            bridge.text = "no"
+
+        pathraise = "./focus/raiseOnFocus"
+        bridgeraise = root.find(pathraise)
+
+        if bridgeraise == None:
+            return False
+
+        if focus_mode == Mode.MOUSE:
+            bridgeraise.text = "yes"
+        else:
+            bridgeraise.text = "no"
+
+        auto_raise_delay = self.desktop_wm_preferences_settings["auto-raise-delay"]
+
+        pathraisedelay = "./focus/raiseOnFocusDelay"
+        bridgeraisedelay = root.find(pathraisedelay)
+
+        if bridgeraisedelay == None:
+            focus = "./focus"
+            bridgeraisedelay = root.find(focus)
+            new_key = Et.Element("raiseOnFocusDelay")
+            bridgeraisedelay.append(new_key)
+
+            bridgeraisedelay = root.find(pathraisedelay)
+
+        bridgeraisedelay.text = str(auto_raise_delay)
+
+        return True
+
     # all solus-project budgie-wm gsettings changes are managed
     def budgie_wm_changed(self, settings, key):
         root = self.et.getroot()
@@ -1199,36 +1249,8 @@ class Bridge:
         updated = False
 
         if key == "window-focus-mode":
-            path = "./focus/followMouse"
-            bridge = root.find(path)
-
-            if bridge == None:
-                return
-
-            class Mode(StrEnum):
-                CLICK = 'click'
-                SLOPPY = 'sloppy'
-                MOUSE = 'mouse'
-
-            focus_mode = settings[key]
-
-            if focus_mode != Mode.CLICK:
-                bridge.text = "yes"
-            else:
-                bridge.text = "no"
-
-            updated = True
-
-            pathraise = "./focus/raiseOnFocus"
-            bridgeraise = root.find(pathraise)
-
-            if bridgeraise == None:
-                return
-
-            if focus_mode == Mode.MOUSE:
-                bridgeraise.text = "yes"
-            else:
-                bridgeraise.text = "no"
+            if self._process_focus_mode():
+                updated = True
 
         if key == "show-all-windows-tabswitcher":
             path = "./windowSwitcher"
@@ -1340,6 +1362,10 @@ class Bridge:
             bridge.attrib["number"] = str(settings[key])
 
             updated = True
+
+        if key == "auto-raise-delay":
+            if self._process_focus_mode():
+                updated = True
 
         if updated:
             self.write_config()


### PR DESCRIPTION
## Description

bridge support for labwc raiseOnFocusDelay - use with Mouse FocusMode to delay switching

## Test plan

labwc 0.20
start the bridge - confirm new raiseonfocusdelay key was created in the focus xml section

switch focus-mode to mouse and open two windows - move your mouse out of one window and within the bridge key value (500ms by default) switch back. Confirm that windows hasn't automatically been raised.

Now repeat but move the mouse much more slowly - confirm that the windows are raised.

### Submitter Checklist

- [X] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-desktop and verified that the patch worked (if needed)
- [ ] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable

<!-- Supplemental comments on the PR with AI prompt/planning information are welcome and encouraged for research and learnings, but not mandatory. Share them as PR comments, not committed to the repository. -->
