### PR TITLE
panel/manager: Fix potential crash when checking for primary monitor

### DIFF
--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -374,6 +374,11 @@ namespace Budgie {
 		* note Xfw window geometry includes scale factors
 		*/
 		bool window_on_primary(Xfw.Window? window) {
+			if (window == null) {
+				warning("Tried to check which monitor a window was on, but it was NULL");
+				return false;
+			}
+
 			unowned Gdk.Monitor? primary_monitor = this.get_primary_monitor();
 
 			if (primary_monitor == null) {
@@ -382,6 +387,11 @@ namespace Budgie {
 			}
 
 			unowned var monitors = window.get_monitors();
+
+			if (monitors == null) {
+				debug("Monitors for window is NULL");
+				return false;
+			}
 
 			foreach (var monitor in monitors) {
 				unowned var gdk_monitor = monitor.get_gdk_monitor();


### PR DESCRIPTION
## Description

One prevalent crash being caught by the Ubuntu error tracker is happening in the panel manager when we check if a window is on the primary monitor. Let's add some guards to hopefully prevent this crash.

## Test plan

Re-built Budgie, and restarted the panel.

### Submitter Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
- [ ] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable

<!-- Supplemental comments on the PR with AI prompt/planning information are welcome and encouraged for research and learnings, but not mandatory. Share them as PR comments, not committed to the repository. -->
