### PR TITLE
cleanup: Remove G_GNUC_CONST for *_get_type functions

### DIFF
--- a/src/plugin/panel/budgie-enums.h.template
+++ b/src/plugin/panel/budgie-enums.h.template
@@ -16,7 +16,7 @@ G_BEGIN_DECLS
 /*** END file-production ***/
 
 /*** BEGIN value-header ***/
-GType @enum_name@_get_type (void) G_GNUC_CONST;
+GType @enum_name@_get_type (void);
 #define @ENUMPREFIX@_TYPE_@ENUMSHORT@ (@enum_name@_get_type ())
 /*** END value-header ***/
 

--- a/src/plugin/raven/budgie-raven-enums.h.template
+++ b/src/plugin/raven/budgie-raven-enums.h.template
@@ -13,7 +13,7 @@ G_BEGIN_DECLS
 /*** END file-production ***/
 
 /*** BEGIN value-header ***/
-GType @enum_name@_get_type (void) G_GNUC_CONST;
+GType @enum_name@_get_type (void);
 #define @ENUMPREFIX@_TYPE_@ENUMSHORT@ (@enum_name@_get_type ())
 /*** END value-header ***/
 


### PR DESCRIPTION
## Description

GLib recently removed `G_GNUC_CONST` attributes from its `*get_type` declarations to avoid miscompilations with GCC trunk. This does the same for us, meaning we have one less thing to worry about for the next GCC release.

Fixes https://github.com/BuddiesOfBudgie/budgie-session/issues/11
Ref https://gitlab.gnome.org/GNOME/glib/-/merge_requests/5223

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>

## Test plan

Successfully built `budgie-desktop`.

### Submitter Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
- [ ] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable

<!-- Supplemental comments on the PR with AI prompt/planning information are welcome and encouraged for research and learnings, but not mandatory. Share them as PR comments, not committed to the repository. -->
