### PR TITLE
fix(panel): Super key doesn't focus app menu search box (#842)

### DIFF
--- a/src/panel/applets/budgie-menu/BudgieMenu.vala
+++ b/src/panel/applets/budgie-menu/BudgieMenu.vala
@@ -167,6 +167,12 @@ public class BudgieMenuApplet : Budgie.Applet {
 				popover.hide();
 			} else {
 				popover.get_child().show_all();
+				// Explicitly reset (which sets the search entry as the popover's
+				// tracked focus_child) before showing. manager.show_popover() does
+				// NOT call popover.show()/our BudgieMenuWindow.show() override, so
+				// without this the focus_child bookkeeping reset() performs never
+				// runs via this code path. See: https://github.com/BuddiesOfBudgie/budgie-desktop/issues/842
+				popover.reset(true);
 				this.manager.show_popover(widget);
 			}
 			return Gdk.EVENT_STOP;
@@ -216,6 +222,11 @@ public class BudgieMenuApplet : Budgie.Applet {
 				popover.hide();
 			} else {
 				popover.get_child().show_all();
+				// See the identical comment in the button_press_event handler above:
+				// manager.show_popover() never triggers our BudgieMenuWindow.show()
+				// override, so reset() (which sets the search entry as focus_child)
+				// must be called explicitly here too. See: https://github.com/BuddiesOfBudgie/budgie-desktop/issues/842
+				popover.reset(true);
 				this.manager.show_popover(widget);
 			}
 		}

--- a/src/panel/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/src/panel/applets/budgie-menu/BudgieMenuWindow.vala
@@ -220,6 +220,28 @@ public class BudgieMenuWindow : Gtk.Popover {
 		base.show();
 	}
 
+	// GtkPopover hard-overrides grab_focus() (see gtk-3-24's gtkpopover.c,
+	// gtk_popover_grab_focus()) to unconditionally do:
+	//   child_focus(gtk_bin_get_child(popover), GTK_DIR_TAB_FORWARD)
+	// -- a relative TAB-order descent from whatever the popover's current
+	// focus_child already is. Since reset() already correctly sets focus_child to
+	// search_entry (via search_entry.grab_focus()), any later plain
+	// gtk_widget_grab_focus(popover) call (as done by popover-manager.c's deferred
+	// focus-in-event handler, needed to re-assert focus once real Wayland keyboard
+	// focus actually arrives) tabs PAST the already-focused search entry onto
+	// whatever's next -- landing on the active category radio button instead.
+	// Overriding grab_focus() here means popover-manager.c's existing
+	// gtk_widget_grab_focus(w) call (w = this popover) dispatches straight to
+	// search_entry instead, with no directional-descent side effects. This fixes
+	// both the initial reset() grab and the later re-assertion grab to agree on the
+	// same target. See: https://github.com/BuddiesOfBudgie/budgie-desktop/issues/842
+	public override void grab_focus() {
+		if (!this.get_mapped()) {
+			return;
+		}
+		this.search_entry.grab_focus();
+	}
+
 	/**
 	 * Opens our overlay menu and makes all other widgets insensitive.
 	 */

--- a/src/plugin/panel/popover-manager.c
+++ b/src/plugin/panel/popover-manager.c
@@ -31,6 +31,8 @@ G_DEFINE_TYPE_WITH_PRIVATE(BudgiePopoverManager, budgie_popover_manager, G_TYPE_
 
 static void budgie_popover_manager_widget_died(BudgiePopoverManager* self, GtkWidget* child);
 static gboolean on_focus_out(GtkWidget *widget, GdkEvent *event, GtkPopover *popover);
+static void on_popover_closed_restore_keyboard_mode(GtkPopover *popover, GtkWindow *toplevel);
+static gboolean on_toplevel_focus_in_grab_widget(GtkWidget *toplevel_widget, GdkEvent *event, GtkWidget *w);
 
 /**
  * budgie_popover_manager_new:
@@ -125,25 +127,98 @@ void budgie_popover_manager_show_popover(BudgiePopoverManager* self, GtkWidget* 
 		gtk_popover_set_position(popover, GTK_POS_LEFT);
 	}
 
+	// GtkPopover (GTK3) is a GtkBin, NOT a GtkWindow. It never gets its own Wayland
+	// surface role (no xdg_popup, no layer-surface) -- it renders via a wl_subsurface
+	// parented to its *toplevel*, and routes keyboard input through an in-process GTK
+	// grab. That in-process grab only has real key events to redirect if the toplevel
+	// itself already holds actual Wayland keyboard focus.
+	//
+	// Mouse-opened popovers work because clicking the panel gives the panel's own
+	// zwlr_layer_surface_v1 keyboard focus (labwc honours the click), so the popover's
+	// internal grab has input to intercept. Keyboard-shortcut-opened popovers (e.g.
+	// Super to open the app menu) fail because the panel's layer-surface sits at
+	// KEYBOARD_MODE_ON_DEMAND -- no click, no focus, nothing for the grab to redirect.
+	//
+	// The previous approach here tried to promote the *popover's own* GdkWindow to a
+	// zwlr_layer_surface_v1 via gtk_layer_init_for_window(). That can never work:
+	// GtkPopover isn't a GtkWindow, so gtk-layer-shell's "linked-gtk-window" data key
+	// (only set on windows gtk-layer-shell already manages) is never present on a
+	// popover's GdkWindow -- the lookup returns garbage/NULL and every subsequent
+	// gtk_layer_* call is a no-op on nothing.
+	//
+	// The actual fix: toggle keyboard-interactivity on the PANEL's already-existing
+	// layer-surface (which Budgie itself owns and already manages via GtkLayerShell)
+	// to EXCLUSIVE right before popping the menu open, then grab focus into the
+	// popover's own search entry so GTK's internal focus chain routes the now-real
+	// keyboard events there. Revert to ON_DEMAND when the popover closes so we don't
+	// trap the compositor keyboard globally. See: https://github.com/BuddiesOfBudgie/budgie-desktop/issues/842
+	GtkWindow *toplevel_win = GTK_IS_WINDOW(toplevel) ? GTK_WINDOW(toplevel) : NULL;
+
+	if (toplevel_win != NULL && gtk_layer_is_layer_window(toplevel_win)) {
+		gtk_layer_set_keyboard_mode(toplevel_win, GTK_LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE);
+
+		// Make sure we drop EXCLUSIVE again once the popover is dismissed, on every
+		// exit path (Esc via on_focus_out's hide(), click-away, app launched, etc.)
+		// -- all of them end up hiding the popover, so "hide" is the one signal that
+		// reliably fires for all of them.
+		g_signal_connect(popover, "hide", G_CALLBACK(on_popover_closed_restore_keyboard_mode), toplevel_win);
+
+		// The EXCLUSIVE request above only takes effect on a LATER Wayland roundtrip
+		// (labwc processes the layer-surface commit, then sends wl_keyboard.enter
+		// asynchronously) -- it is NOT synchronous with this function call.
+		if (gtk_window_has_toplevel_focus(toplevel_win)) {
+			// Edge case: the panel already held real wl_keyboard focus (e.g. it was
+			// just clicked moments before Super was pressed). Flipping to EXCLUSIVE
+			// on an already-focused surface produces no NEW wl_keyboard.enter, so
+			// waiting for focus-in-event would hang forever. Grab immediately.
+			gtk_widget_grab_focus(w);
+		} else {
+			// Idempotent arm: guard against show->show without an intervening hide
+			// stacking multiple handlers (e.g. rapid double Super-press).
+			g_signal_handlers_disconnect_by_func(toplevel_win, G_CALLBACK(on_toplevel_focus_in_grab_widget), w);
+			// Use _after + connect_object: GtkWindow's own default focus-in handler
+			// (gtk_window_focus_in_event) re-establishes toplevel-focus bookkeeping
+			// against its stored focus_widget when wl_keyboard.enter arrives. If our
+			// handler ran BEFORE that default handler, our grab could be clobbered
+			// by stale state. G_CONNECT_AFTER guarantees we run after GTK's own
+			// bookkeeping settles. connect_object also auto-disconnects if `w` (the
+			// widget we intend to focus) is destroyed while still armed, avoiding a
+			// dangling callback into freed memory.
+			g_signal_connect_object(toplevel_win, "focus-in-event", G_CALLBACK(on_toplevel_focus_in_grab_widget), w, G_CONNECT_AFTER);
+		}
+	} else {
+		// No layer-surface to wait on (e.g. mouse-click path where the toplevel
+		// already has focus) -- grab immediately as before.
+		gtk_widget_grab_focus(w);
+	}
+
 	gtk_popover_popup(popover);
 
 	// Ensures the default widget (input) is activated
 	gtk_widget_set_can_default(w, TRUE);
 	gtk_widget_grab_default(w);
+}
 
-	GdkWindow * gdk_window = gtk_widget_get_window(w);
+static gboolean on_toplevel_focus_in_grab_widget(GtkWidget *toplevel_widget, GdkEvent *event, GtkWidget *w) {
+	if (GTK_IS_WIDGET(w) && gtk_widget_get_visible(w)) {
+		gtk_widget_grab_focus(w);
+	}
+	// One-shot: this signal fires every time the panel regains keyboard focus, but we
+	// only need to redirect focus the first time after opening it. (g_signal_connect_object
+	// ties this handler's lifetime to `w`, so no manual disconnect needed for cleanup,
+	// but we still want to stop reacting after the first fire per open.)
+	g_signal_handlers_disconnect_by_func(toplevel_widget, G_CALLBACK(on_toplevel_focus_in_grab_widget), w);
+	return GDK_EVENT_PROPAGATE;
+}
 
-	if (!GDK_IS_WINDOW(gdk_window)) return;
-
-	// Thanks gtk-layer-shell for the following conversion code for getting the GtkWindow from a GdkWaylandWindow
-	GtkWindow *popover_win = GTK_WINDOW (g_object_get_data (G_OBJECT (gdk_window), "linked-gtk-window"));
-	if (!GTK_IS_WINDOW(popover_win)) return;
-
-	// Ensure gtk layer shell is initialised for the popover window, needs to be done after being realized
-	gtk_layer_init_for_window(popover_win);
-
-	gtk_layer_set_layer(popover_win, GTK_LAYER_SHELL_LAYER_TOP);
-	gtk_layer_set_keyboard_mode(popover_win, GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND);
+static void on_popover_closed_restore_keyboard_mode(GtkPopover *popover, GtkWindow *toplevel) {
+	if (toplevel != NULL && GTK_IS_WINDOW(toplevel) && gtk_layer_is_layer_window(toplevel)) {
+		gtk_layer_set_keyboard_mode(toplevel, GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND);
+	}
+	g_signal_handlers_disconnect_by_func(popover, G_CALLBACK(on_popover_closed_restore_keyboard_mode), toplevel);
+	// In case the popover was closed before focus-in ever fired (e.g. reopened/closed
+	// quickly), make sure we don't leave a stale one-shot handler connected.
+	g_signal_handlers_disconnect_by_func(toplevel, G_CALLBACK(on_toplevel_focus_in_grab_widget), popover);
 }
 
 static gboolean on_focus_out(GtkWidget *widget, GdkEvent *event, GtkPopover *popover) {


### PR DESCRIPTION
## Description

Pressing `Super_L` opens the app menu popover visually, but keyboard input still goes to whatever window was previously focused. Opening the same menu with a mouse click works correctly.

This is fixable entirely in Budgie — it is **not** a compositor/wlroots bug and does **not** depend on labwc PR #3375 or wlroots MR !5265 (`xdg_popup` grab event). Those only affect `xdg_popup`-role surfaces; `GtkPopover` never uses that role under GTK3.

### Root cause (stacked)

1. **`GtkPopover` has no Wayland surface role of its own** — GTK3 renders it via a `wl_subsurface` and routes keyboard input through an in-process GTK grab. That grab only works if the parent toplevel (the panel) already holds real Wayland keyboard focus. The Super-key path never focuses the panel's `ON_DEMAND` layer-surface.
2. **`set_keyboard_interactivity(EXCLUSIVE)` is async** — focus must be grabbed from the toplevel's `focus-in-event` (GDK's representation of `wl_keyboard.enter`), not synchronously.
3. **Both call sites bypass `reset()`** — `invoke_action()` and the mouse handler call `manager.show_popover()` without `popover.show()`, so `BudgieMenuWindow.reset()` never marks the search entry as `focus_child`.
4. **`GtkPopover.grab_focus()` always does `TAB_FORWARD` descent** — even after `reset()`, a later `grab_focus(popover)` advances past the search entry onto the active category button.

### Fix

- `popover-manager.c`: toggle the panel layer-surface to `EXCLUSIVE` before showing, restore `ON_DEMAND` on hide; defer focus grab to `focus-in-event` (`G_CONNECT_AFTER`) when needed.
- `BudgieMenu.vala`: call `popover.reset(true)` before `show_popover()` at both call sites.
- `BudgieMenuWindow.vala`: override `grab_focus()` to target `search_entry` directly.

Fixes #842

## Test plan

- [x] Fresh clone, clean `ninja` build (499/499) on an independent checkout
- [x] Live verification: after pressing Super, typed characters land in the search box with zero clicks
- [x] Verified with `WAYLAND_DEBUG=1` protocol traces (popover is subsurface; panel gets EXCLUSIVE then reverts to ON_DEMAND)
- [ ] Mouse-click open still focuses search entry
- [ ] Esc / click-away / app launch restore panel keyboard mode (`ON_DEMAND`)
- [ ] Rapid double-Super does not leave stale focus handlers

### Submitter Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
- [x] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable


Made with [Cursor](https://cursor.com)