### PR TITLE
fix(session) switch bash for /bin/sh in startbudgielabwc script

### DIFF
--- a/src/session/startbudgielabwc.in
+++ b/src/session/startbudgielabwc.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 OPTS=""
 for OPT in "$@"; do
     if test "${OPT}" = "--help"; then


### PR DESCRIPTION
## Description

In startbudgielabwc script `#!/usr/bin/env bash` has been replaced with `/bin/sh`.  This makes the script POSIX compatible, and removes the need for bash 

## Test plan

Edited /usr/bin/startbudgielabwc with change on running system, uninstalled bash, and rebooted. Logged in with no issues.
Tested on busybox ash and dash

### Submitter Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
- [x] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable

Small commit, ties into bigger commit on budgie-session repository
