### PR TITLE
fix(raven): anchor to the vertical edges instead of sizing from panels

### DIFF
--- a/src/lib/toplevel.vala
+++ b/src/lib/toplevel.vala
@@ -37,6 +37,22 @@ namespace Budgie {
 		public int intended_size { public set ; public get; }
 
 		/**
+		* The extent of our window along the same axis as intended_size,
+		* including the shadow when it is visible
+		*/
+		public int targeted_size {
+			public get {
+				return intended_size + (shadow_visible ? ShadowBlock.SIZE : 0);
+			}
+		}
+
+		/**
+		* Thickness of the panel itself as allocated, excluding the shadow.
+		* This is the space we take from other surfaces
+		*/
+		public int reserved_size { public set; public get; }
+
+		/**
 		* Our configured applet spacing
 		*/
 		public int intended_spacing { public set; public get; }
@@ -55,6 +71,17 @@ namespace Budgie {
 		public Budgie.PanelTransparency transparency { public set; public get; default = Budgie.PanelTransparency.NONE; }
 		public Budgie.AutohidePolicy autohide { public set; public get; default = Budgie.AutohidePolicy.NONE; }
 
+		construct {
+			// Run on_size_input_changed whenever either of these two properties is set
+			notify["intended-size"].connect(on_size_input_changed);
+			notify["shadow-visible"].connect(on_size_input_changed);
+		}
+
+		private void on_size_input_changed() {
+			// targeted_size has no setter, so nothing emits notify for it on its own,
+			// so we need to basically notify on its behalf
+			notify_property("targeted-size");
+		}
 
 		public abstract List<Budgie.AppletInfo?> get_applets();
 		public signal void applet_added(Budgie.AppletInfo? info);

--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -503,8 +503,6 @@ namespace Budgie {
 			unowned string uuid;
 			unowned Budgie.Panel panel;
 			unowned Screen? primary;
-			unowned Budgie.Panel? top = null;
-			unowned Budgie.Panel? bottom = null;
 			screens.remove_all();
 
 			int n_monitors = dis.get_n_monitors();
@@ -601,23 +599,9 @@ namespace Budgie {
 				panel_area.x, panel_area.y);
 				panel.update_geometry(panel_area, panel.position, primary_monitor);
 
-				if (panel.position == Budgie.PanelPosition.TOP) {
-					top = panel;
-				} else if (panel.position == Budgie.PanelPosition.BOTTOM) {
-					bottom = panel;
-				}
 				/* Re-take the position */
 				primary.slots |= panel.position;
 			}
-
-			debug("Updating Raven geometry");
-			// Also normalize for Raven
-			Gdk.Rectangle raven_area = Gdk.Rectangle();
-			raven_area.x = 0;
-			raven_area.y = 0;
-			raven_area.width = primary.area.width;
-			raven_area.height = primary.area.height;
-			this.raven.update_geometry(raven_area);
 		}
 
 		private void on_bus_acquired(DBusConnection conn) {
@@ -858,6 +842,10 @@ namespace Budgie {
 			var settings = new Settings.with_path(Budgie.TOPLEVEL_SCHEMA, path);
 			Budgie.Panel? panel = new Budgie.Panel(this, panel_plugin_manager, uuid, settings);
 			panels.insert(uuid, panel);
+
+			// Whenever a panel's reserved size changes (what it actually takes up), call update screen
+			// This will update all panel geometry as well as Raven's
+			panel.notify["reserved-size"].connect(this.update_screen);
 
 			if (!configure) {
 				return;
@@ -1104,7 +1092,6 @@ namespace Budgie {
 			Budgie.Toplevel? bottom = null;
 			Budgie.Toplevel? right = null;
 			Budgie.Toplevel? left = null;
-			Gdk.Rectangle raven_screen;
 
 			string? key = null;
 			Budgie.Panel? val = null;
@@ -1146,11 +1133,11 @@ namespace Budgie {
 					geom.width = area.area.width;
 					geom.height = area.area.height;
 					if (this.is_panel_huggable(top)) {
-						geom.y += top.intended_size;
-						geom.height -= top.intended_size;
+						geom.y += top.reserved_size;
+						geom.height -= top.reserved_size;
 					}
 					if (this.is_panel_huggable(bottom)) {
-						geom.height -= bottom.intended_size;
+						geom.height -= bottom.reserved_size;
 					}
 					val2.update_geometry(geom, val2.position, val2.intended_size);
 					break;
@@ -1160,40 +1147,20 @@ namespace Budgie {
 				}
 			}
 
-			raven_screen = area.area;
-			if (top != null && !top.dock_mode && top.autohide == AutohidePolicy.NONE) {
-				raven_screen.y += top.intended_size;
-				raven_screen.height -= top.intended_size;
-			}
-
-			if (bottom != null && !bottom.dock_mode && bottom.autohide == AutohidePolicy.NONE) {
-				raven_screen.height -= bottom.intended_size;
-			}
-
 			// Set which side of the screen Raven should appear on
 			switch (raven_position) {
 				case RavenPosition.LEFT:
-					/* Stick/maybe hug left */
 					raven.screen_edge = Gtk.PositionType.LEFT;
-					if (left != null) {
-						raven_screen.x += left.intended_size;
-					}
 					break;
 				case RavenPosition.RIGHT:
-					/* Stick/maybe hug right */
 					raven.screen_edge = Gtk.PositionType.RIGHT;
-					if (right != null) {
-						raven_screen.width -= (right.intended_size);
-					}
 					break;
 				case RavenPosition.AUTOMATIC:
 				default:
-					set_raven_position(left, right, ref raven_screen);
+					set_raven_position(left, right);
 					break;
 			}
 
-			/* Let Raven update itself accordingly */
-			raven.update_geometry(raven_screen);
 			this.panels_changed();
 		}
 
@@ -1211,44 +1178,28 @@ namespace Budgie {
 		}
 
 		/**
-		 * Use the current panel layouts to figure out Raven's position.
-		 *
-		 * This function sets which side of the screen Raven should be on,
-		 * as well as Raven's position or width (if it's on the right side).
+		 * Use the current panel layouts to figure out which side of the screen
+		 * Raven should be on.
 		 */
-		void set_raven_position(Toplevel? left, Toplevel? right, ref Gdk.Rectangle raven_screen) {
+		void set_raven_position(Toplevel? left, Toplevel? right) {
 			if (left != null && right == null) {
 				if (this.is_panel_huggable(left)) {
-					/* Hug left */
 					raven.screen_edge = Gtk.PositionType.LEFT;
-					raven_screen.x += left.intended_size;
 				} else {
-					/* Stick right */
 					raven.screen_edge = Gtk.PositionType.RIGHT;
 				}
 			} else if (right != null && left == null) {
 				if (this.is_panel_huggable(right)) {
-					/* Hug right */
-					raven_screen.width -= (right.intended_size);
 					raven.screen_edge = Gtk.PositionType.RIGHT;
 				} else {
-					/* Stick left */
 					raven.screen_edge = Gtk.PositionType.LEFT;
 				}
 			} else if (is_panel_huggable(left) && !is_panel_huggable(right)) {
-				/* Hug left */
 				raven.screen_edge = Gtk.PositionType.LEFT;
-				raven_screen.x += left.intended_size;
 			} else if (is_panel_huggable(right) && !is_panel_huggable(left)) {
-				/* Hug right */
-				raven_screen.width -= (right.intended_size);
 				raven.screen_edge = Gtk.PositionType.RIGHT;
 			} else {
-				/* Stick/maybe hug right */
 				raven.screen_edge = Gtk.PositionType.RIGHT;
-				if (right != null) {
-					raven_screen.width -= (right.intended_size);
-				}
 			}
 		}
 

--- a/src/panel/panel.vala
+++ b/src/panel/panel.vala
@@ -222,9 +222,6 @@ namespace Budgie {
 			position = PanelPosition.NONE;
 		}
 
-		/* Multiplier for strut operations on hi-dpi */
-		int scale = 1;
-
 		/* Box for the start of the panel */
 		ConstrainedBox? start_box;
 		/* Box for the center of the panel */
@@ -432,6 +429,7 @@ namespace Budgie {
 
 			intended_size = settings.get_int(Budgie.PANEL_KEY_SIZE);
 			intended_spacing = settings.get_int(Budgie.PANEL_KEY_SPACING);
+			reserved_size = intended_size;
 			this.manager = manager;
 			this.plugin_manager = plugin_manager;
 
@@ -439,12 +437,10 @@ namespace Budgie {
 			skip_pager_hint = true;
 			set_decorated(false);
 
-			scale = get_scale_factor();
 			nscale = 1.0;
 
 			// Respond to a scale factor change
 			notify["scale-factor"].connect(() => {
-				this.scale = get_scale_factor();
 				this.placement();
 			});
 
@@ -516,19 +512,6 @@ namespace Budgie {
 			this.enter_notify_event.connect(on_enter_notify);
 			this.leave_notify_event.connect(on_leave_notify);
 
-			// Connect size_allocate signals to update margins when size changes
-			// Only update margins for main_layout to avoid recursive issues
-			//  main_layout.size_allocate.connect(() => {
-			//  	// Only update margins if we're in dock mode and have valid allocations
-			//  	if (this.dock_mode) {
-			//  		Gtk.Allocation alloc;
-			//  		main_layout.get_allocation(out alloc);
-			//  		if (alloc.width > 0 && alloc.height > 0) {
-			//  			update_panel_margins();
-			//  		}
-			//  	}
-			//  });
-
 			get_child().show_all();
 
 			// Immediately hide our inner boxes
@@ -537,6 +520,9 @@ namespace Budgie {
 			end_box.hide();
 
 			this.plugin_manager.extension_loaded.connect_after(this.on_extension_loaded);
+
+			this.notify["targeted-size"].connect(this.placement);
+			this.layout.size_allocate.connect(this.on_layout_allocated);
 
 			/* bit of a no-op. */
 			update_sizes();
@@ -601,9 +587,7 @@ namespace Budgie {
 		}
 
 		// For dock mode, calculate margins to center the panel
-		bool horizontal = (position == PanelPosition.TOP || position == PanelPosition.BOTTOM);
-
-		if (horizontal) {
+		if (is_horizontal()) {
 			// For horizontal panels (TOP/BOTTOM), center horizontally
 			// Calculate equal left and right margins to center the panel
 			int available_width = orig_scr.width - main_alloc.width;
@@ -634,9 +618,7 @@ namespace Budgie {
 		calculate_panel_margins(out margin_top, out margin_bottom, out margin_left, out margin_right);
 
 		// Set margins using GtkLayerShell - set relevant margins and zero out the others
-		bool horizontal = (position == PanelPosition.TOP || position == PanelPosition.BOTTOM);
-
-		if (horizontal) {
+		if (is_horizontal()) {
 		  	// For horizontal panels (TOP/BOTTOM), set left/right margins and zero top/bottom
 		  	GtkLayerShell.set_margin(this, GtkLayerShell.Edge.TOP, -1);
 		  	GtkLayerShell.set_margin(this, GtkLayerShell.Edge.BOTTOM, -1);
@@ -660,7 +642,7 @@ namespace Budgie {
 			GtkLayerShell.set_exclusive_zone(this, 0);
 			set_below_other_surfaces();
 		} else {
-			GtkLayerShell.set_exclusive_zone(this, this.intended_size);
+			GtkLayerShell.set_exclusive_zone(this, this.reserved_size);
 			set_above_other_surfaces();
 		}
 	}
@@ -1286,7 +1268,7 @@ namespace Budgie {
 
 		void placement() {
 			this.update_layer_shell_props();
-			bool horizontal = false;
+			bool horizontal = is_horizontal();
 			Gtk.Allocation alloc;
 			main_layout.get_allocation(out alloc);
 
@@ -1294,67 +1276,42 @@ namespace Budgie {
 			int x = 0, y = 0;
 			int shadow_position = 0;
 
-			// Get monitor geometry to constrain panel size
-			Gdk.Rectangle monitor_geom = orig_scr;
-
-			// Constrain orig_scr to monitor dimensions
-			int max_width = monitor_geom.width;
-			int max_height = monitor_geom.height;
+			get_target_extents(out width, out height);
 
 			switch (position) {
 				case Budgie.PanelPosition.TOP:
 					x = orig_scr.x;
 					y = orig_scr.y;
-					width = int.min(orig_scr.width, max_width);
-					height = intended_size;
 					shadow_position = 1;
-					horizontal = true;
 					break;
 				case Budgie.PanelPosition.LEFT:
 					x = orig_scr.x;
 					y = orig_scr.y;
-					width = intended_size;
-					height = int.min(orig_scr.height, max_height);
 					shadow_position = 1;
 					break;
 				case Budgie.PanelPosition.RIGHT:
 					x = (orig_scr.x + orig_scr.width) - alloc.width;
 					y = orig_scr.y;
-					width = intended_size;
-					height = int.min(orig_scr.height, max_height);
 					shadow_position = 0;
 					break;
 				case Budgie.PanelPosition.BOTTOM:
 				default:
 					x = orig_scr.x;
 					y = orig_scr.y + (orig_scr.height - alloc.height);
-					width = int.min(orig_scr.width, max_width);
-					height = intended_size;
 					shadow_position = 0;
-					horizontal = true;
 					break;
 			}
 
 			// Special considerations for dock mode
 			if (this.dock_mode) {
+				// A dock is only as long as its applets: cap it at the screen if they
+				// overflow, otherwise request a small size and let them set the length
 				if (horizontal) {
-					if (alloc.width > max_width) {
-						width = max_width;
-					} else {
-						width = 100;
-					}
+					width = (alloc.width > orig_scr.width) ? orig_scr.width : 100;
 				} else {
-					if (alloc.height > max_height) {
-						height = max_height;
-					} else {
-						height = 100;
-					}
+					height = (alloc.height > orig_scr.height) ? orig_scr.height : 100;
 				}
 			}
-
-			// Ensure width and height don't exceed monitor dimensions
-			width = int.min(width, max_width);
-			height = int.min(height, max_height);
 
 			main_layout.child_set(shadow, "position", shadow_position);
 
@@ -1405,64 +1362,60 @@ namespace Budgie {
 				main_layout.hexpand = true;
 			}
 
-			layout.set_size_request(width, height);
+			// The panel is intended_size. The window is intended_size plus the shadow.
+			layout.set_size_request(
+				horizontal ? width : intended_size,
+				horizontal ? intended_size : height
+			);
 			set_size_request(width, height);
 		}
 
 		public override void get_preferred_width(out int minimum_width, out int natural_width) {
-			// Get monitor geometry to constrain panel size
-			Gdk.Rectangle monitor_geom = orig_scr;
-			var screen = get_screen();
-			if (screen != null) {
-				var display = screen.get_display();
-				if (display != null) {
-					var monitor = display.get_primary_monitor();
-					if (monitor != null) {
-						monitor_geom = monitor.get_geometry();
-					}
-				}
-			}
+			int width, height;
+			get_target_extents(out width, out height);
 
-			int max_width = monitor_geom.width;
-			bool horizontal = (position == Budgie.PanelPosition.TOP || position == Budgie.PanelPosition.BOTTOM);
-
-			if (horizontal) {
-				// For horizontal panels, constrain width to monitor width
-				minimum_width = int.min(orig_scr.width, max_width);
-				natural_width = int.min(orig_scr.width, max_width);
-			} else {
-				// For vertical panels, width is the intended_size
-				minimum_width = intended_size;
-				natural_width = intended_size;
-			}
+			minimum_width = width;
+			natural_width = width;
 		}
 
 		public override void get_preferred_height(out int minimum_height, out int natural_height) {
-			// Get monitor geometry to constrain panel size
-			Gdk.Rectangle monitor_geom = orig_scr;
-			var screen = get_screen();
-			if (screen != null) {
-				var display = screen.get_display();
-				if (display != null) {
-					var monitor = display.get_primary_monitor();
-					if (monitor != null) {
-						monitor_geom = monitor.get_geometry();
-					}
-				}
-			}
+			int width, height;
+			get_target_extents(out width, out height);
 
-			int max_height = monitor_geom.height;
-			bool horizontal = (position == Budgie.PanelPosition.TOP || position == Budgie.PanelPosition.BOTTOM);
+			minimum_height = height;
+			natural_height = height;
+		}
 
-			if (horizontal) {
-				// For horizontal panels, height is the intended_size
-				minimum_height = intended_size;
-				natural_height = intended_size;
+		private bool is_horizontal() {
+			return (position == Budgie.PanelPosition.TOP || position == Budgie.PanelPosition.BOTTOM);
+		}
+
+		/**
+		* The size of our window: our full thickness on the axis we're thin on,
+		* the extent of our screen area on the other
+		*/
+		private void get_target_extents(out int width, out int height) {
+			if (is_horizontal()) {
+				width = orig_scr.width;
+				height = int.min(targeted_size, orig_scr.height);
 			} else {
-				// For vertical panels, constrain height to monitor height
-				minimum_height = int.min(orig_scr.height, max_height);
-				natural_height = int.min(orig_scr.height, max_height);
+				width = int.min(targeted_size, orig_scr.width);
+				height = orig_scr.height;
 			}
+		}
+
+		private void on_layout_allocated(Gtk.Allocation allocation) {
+			if (this.position == PanelPosition.NONE) {
+				return;
+			}
+
+			int allocated_size = is_horizontal() ? allocation.height : allocation.width;
+			if (allocated_size == this.reserved_size) {
+				return;
+			}
+
+			this.reserved_size = allocated_size;
+			this.update_exclusive_zone();
 		}
 
 		private bool applet_at_start_of_region(Budgie.AppletInfo? info) {
@@ -1764,9 +1717,9 @@ namespace Budgie {
 			get_allocation(out alloc);
 			/* Create a compatible buffer for the current scaling factor */
 			var buffer = window.create_similar_image_surface(Cairo.Format.ARGB32,
-															alloc.width * this.scale_factor,
-															alloc.height * this.scale_factor,
-															this.scale_factor);
+															alloc.width,
+															alloc.height,
+															1);
 			var cr2 = new Cairo.Context(buffer);
 
 			propagate_draw(get_child(), cr2);
@@ -1833,7 +1786,7 @@ namespace Budgie {
 
 		private void set_above_other_surfaces() {
 			GtkLayerShell.set_layer(this, GtkLayerShell.Layer.TOP); // Ensure it is above other surfaces
-			GtkLayerShell.set_exclusive_zone(this, this.intended_size);
+			GtkLayerShell.set_exclusive_zone(this, this.reserved_size);
 		}
 
 		private void set_below_other_surfaces() {

--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -199,14 +199,16 @@ namespace Budgie {
 					raven_edge,
 					true
 				);
+
+				// Anchoring both of these leaves the compositor to size us to the
+				// usable area, which already excludes the panels
+				GtkLayerShell.set_anchor(this, GtkLayerShell.Edge.TOP, true);
+				GtkLayerShell.set_anchor(this, GtkLayerShell.Edge.BOTTOM, true);
 		}
 			public get {
 				return this._screen_edge;
 			}
 		}
-
-		int our_width = 0;
-		int our_height = 0;
 
 		private Budgie.ShadowBlock? shadow;
 		private RavenIface? iface = null;
@@ -215,12 +217,9 @@ namespace Budgie {
 
 		bool expanded = false;
 
-		Gdk.Rectangle old_rect;
 		Gtk.Box layout;
 
 		private double scale = 0.0;
-
-		public int required_size { public get ; protected set; }
 
 		private Budgie.MainView? main_view = null;
 
@@ -328,7 +327,6 @@ namespace Budgie {
 
 			// Response to a scale factor change
 			notify["scale-factor"].connect(() => {
-				this.update_geometry(this.old_rect);
 				queue_resize();
 			});
 
@@ -379,47 +377,9 @@ namespace Budgie {
 			this.screen_edge = Gtk.PositionType.RIGHT;
 		}
 
-		public override void size_allocate(Gtk.Allocation rect) {
-			int w = 0;
-
-			base.size_allocate(rect);
-			if ((w = get_allocated_width()) != this.required_size) {
-				this.required_size = w;
-				this.update_geometry(this.old_rect);
-			}
-		}
-
 		public void setup_dbus() {
 			Bus.own_name(BusType.SESSION, Budgie.RAVEN_DBUS_NAME, BusNameOwnerFlags.ALLOW_REPLACEMENT|BusNameOwnerFlags.REPLACE,
 				on_bus_acquired, () => {}, () => { warning("Raven could not take dbus!"); });
-		}
-
-		/**
-		* Update our geometry based on other panels in the neighbourhood, and the screen we
-		* need to be on */
-		public void update_geometry(Gdk.Rectangle rect) {
-			int width = layout.get_allocated_width();
-
-			int height = rect.height;
-
-			this.old_rect = rect;
-
-			our_height = height;
-			our_width = width;
-
-			if (!get_visible()) {
-				queue_resize();
-			}
-		}
-
-		public override void get_preferred_height(out int m, out int n) {
-			m = our_height;
-			n = our_height;
-		}
-
-		public override void get_preferred_height_for_width(int w, out int m, out int n) {
-			m = our_height;
-			n = our_height;
 		}
 
 		public override bool draw(Cairo.Context cr) {
@@ -472,7 +432,6 @@ namespace Budgie {
 			}
 			double old_nscale_op, new_nscale_op;
 			if (exp) {
-				this.update_geometry(this.old_rect);
 				old_nscale_op = 0.0;
 				new_nscale_op = 1.0;
 			} else {


### PR DESCRIPTION
## Description

Raven requested a height of the screen minus the panel sizes while being anchored to one side edge only, so the compositor centered it in the usable area. Whenever those two disagreed it hung over both ends, which is visible as Raven overlapping a bottom panel. Anchoring to TOP and BOTTOM now leaves the height calculation to the compositor, which derives the usable area from all the exclusion zones.

Corrected some panel calculations that accidentally resulted in the "main layout" / content being eaten up by the shadow size. It was only 5 pixels, but this now will actually treat the size set by the user as the actual size of the content, not content - shadow. This "reserved size" is implemented in the `Toplevel` since that is what the panel manager expects as the interface for all the panels.

Also gutted the panel's remaining scale factor usage. The animation buffer no longer multiplies its size by the scale factor. History tells us having scaling code is bad when GTK is handling it, so let's rip this out.

Closes #843
Assisted-by: Claude:claude-opus-5[1m]

## Test plan

1. Used Budgie Desktop before patch, opened wdisplays and change primary monitor (that the panel lives on) to 2.0 scaling. Opened up Raven and confirmed overlap. Change scaling back to 1.0 so I could actually use my computer.
2. Installed budgie-desktop with fix.
3. Replaced panel (`budgie-panel --replace &`).
4. Re-set scaling back to 2.0, opened up Raven and noted it no longer overlaps because the height setting is handled by the compositor.

Screenshot below from 2x scaling:

<img width="3840" height="2160" alt="raven-scale-no-overlap" src="https://github.com/user-attachments/assets/0187ec23-aa33-490b-937e-909ea6a83080" />

### Submitter Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
- [x] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable

<!-- Supplemental comments on the PR with AI prompt/planning information are welcome and encouraged for research and learnings, but not mandatory. Share them as PR comments, not committed to the repository. -->
