### PR TITLE
fix(raven): request keyboard focus so it closes when clicking away

### DIFF
--- a/src/raven/raven.vala
+++ b/src/raven/raven.vala
@@ -214,6 +214,7 @@ namespace Budgie {
 		private RavenIface? iface = null;
 		private Settings? settings = null;
 		private Settings? widget_settings = null;
+		private Settings? wm_settings = null;
 
 		bool expanded = false;
 
@@ -289,6 +290,21 @@ namespace Budgie {
 			return Gdk.EVENT_PROPAGATE;
 		}
 
+		/**
+		* Closing on click-away needs a focus-out event, and a surface only gets one
+		* if it can take keyboard focus. Under sloppy or mouse focus, moving the
+		* pointer toward Raven focuses each window it crosses, which would close
+		* Raven before the pointer arrives, so only ask for focus under click
+		*/
+		private void update_keyboard_mode() {
+			bool click_to_focus = wm_settings.get_string("window-focus-mode") == "click";
+
+			GtkLayerShell.set_keyboard_mode(
+				this,
+				click_to_focus ? GtkLayerShell.KeyboardMode.ON_DEMAND : GtkLayerShell.KeyboardMode.NONE
+			);
+		}
+
 		private void steal_focus() {
 			unowned Gdk.Window? window = get_window();
 			if (window == null) {
@@ -302,9 +318,14 @@ namespace Budgie {
 
 		public Raven(Budgie.DesktopManager? manager, Budgie.RavenPluginManager? plugin_manager) {
 			Object(type_hint: Gdk.WindowTypeHint.DOCK, manager: manager);
+
+			wm_settings = new Settings("com.solus-project.budgie-wm");
+
 			if (Xfw.windowing_get() == Xfw.Windowing.WAYLAND) {
 				GtkLayerShell.init_for_window(this);
 				GtkLayerShell.set_layer(this, GtkLayerShell.Layer.OVERLAY);
+				update_keyboard_mode();
+				wm_settings.changed["window-focus-mode"].connect(update_keyboard_mode);
 			}
 
 			get_style_context().add_class("budgie-container");


### PR DESCRIPTION
## Description

Raven already closed itself on focus-out, but it never asked for keyboard focus, so on Wayland the compositor never focused the surface and no focus-out ever arrived. Requesting ON_DEMAND matches every other layer shell window we have, including the power dialog and the run dialog, both of which pair it with focus-out to close on a click elsewhere.

Only do this under click-to-focus. Under sloppy or mouse focus, moving the pointer toward Raven focuses each window it crosses, which would close Raven before the pointer ever arrives. This is an intentional design decision as I would find it really annoying for it to be closing automatically when I'm using sloppy focus.

Closes #887
Assisted-by: Claude:claude-opus-5[1m]

## Test plan

1. Use budgie-desktop before patch.
2. Open up Raven.
3. Notice that clicking window outside Raven doesn't do anything.
4. Install patch, double check that you have "Window focus mode" set to "Click" (default)
5. Open Raven
6. Click on a window
7. Notice Raven closes

### Submitter Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
- [x] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable

<!-- Supplemental comments on the PR with AI prompt/planning information are welcome and encouraged for research and learnings, but not mandatory. Share them as PR comments, not committed to the repository. --> 