### PR TITLE
fix(tray): stop log spam from menu icons, WindowId and exited apps

### DIFF
--- a/src/panel/applets/tray/DBusMenu.vala
+++ b/src/panel/applets/tray/DBusMenu.vala
@@ -53,7 +53,12 @@ public class DBusMenu : Object {
 		try {
 			iface.get_layout(0, -1, {}, out revision, out layout);
 		} catch (Error e) {
-			warning("Failed to update layout: %s", e.message);
+			if (e is DBusError.SERVICE_UNKNOWN) {
+				// this happens when the application exits while we still have its menu
+				debug("Failed to update layout: %s", e.message);
+			} else {
+				warning("Failed to update layout: %s", e.message);
+			}
 			return;
 		}
 

--- a/src/panel/applets/tray/DBusMenuNode.vala
+++ b/src/panel/applets/tray/DBusMenuNode.vala
@@ -195,7 +195,12 @@ private class DBusMenuItem : Gtk.CheckMenuItem {
 		gicon = (icon_name != "") ? new ThemedIcon.with_default_fallbacks(icon_name) : gicon = new BytesIcon(icon_data);
 		icon.set_from_gicon(gicon, Gtk.IconSize.MENU);
 		icon.set_pixel_size(16);
-		box.pack_start(icon, false, false, 2);
+
+		if (icon.parent == null) {
+			box.pack_start(icon, false, false, 2);
+			box.reorder_child(icon, 0);
+			icon.show();
+		}
 	}
 
 	public void update_shortcut(List<string>? new_shortcut) {

--- a/src/panel/applets/tray/TrayItem.vala
+++ b/src/panel/applets/tray/TrayItem.vala
@@ -30,7 +30,7 @@ internal interface SnItemProperties : Object {
 	public abstract string id {owned get;}
 	public abstract string title {owned get;}
 	public abstract string status {owned get;}
-	public abstract uint32 window_id {get;}
+	public abstract int32 window_id {get;}
 	public abstract string icon_name {owned get;}
 	public abstract SnIconPixmap[] icon_pixmap {owned get;}
 	public abstract string overlay_icon_name {owned get;}


### PR DESCRIPTION
## Description

Three separate sources of noise in the tray applet.

update_icon runs on every icon-name or icon-data property update an application sends for a menu item, and each run packed the same GtkImage into the item's box again. GTK rejects the pack, so the icon was never duplicated, but every attempt logged a gtk_box_pack assertion failure. Apps re-send their menu properties when a StatusNotifier host registers, which is why the failures arrived in bursts of one per menu item.

The StatusNotifierItem spec documents WindowId as a UINT32, but KDE's reference interface XML declares it as an int, and that is what the implementations generated from that XML send. GDBus rejected the property in every GetAll reply and warned about the mismatch. Nothing reads it, and dropping it would only trade that warning for one about an unexpected property.

``` bash
$ cat /usr/share/dbus-1/interfaces/kf6_org.kde.StatusNotifierItem.xml | grep 'WindowId'
    <property name="WindowId" type="i" access="read"/>
```

GetLayout fails with ServiceUnknown when an application exits while we still hold its menu, either racing a LayoutUpdated signal or the initial fetch. The item is torn down right after, so there is nothing to report.

Closes #944

Assisted-by: Claude:claude-opus-5[1m]

## Test plan

1. Run budgie-panel in a terminal before use of this patch.
2. Ensure you have the System Tray added to your panel (any region, doesn't matter)
3. Open up an app, for example: SyncThingy, Zulip, Proton Pass, etc. Something that has a tray.
4. Notice the regular spam of:
	- `(budgie-panel:1025088): Gtk-CRITICAL **: 21:56:31.119: gtk_box_pack: assertion '_gtk_widget_get_parent (child) == NULL' failed`
	- `(budgie-panel:1036138): GLib-GIO-WARNING **: 22:05:55.437: Received property WindowId with type i does not match expected type u in the expected interface`
5. Quit the app and notice `** (budgie-panel:1036138): WARNING **: 22:09:36.917: DBusMenu.vala:56: Failed to update layout: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable`
6. Install patch, restart budgie-panel (`budgie-panel --replace &`)
7. Notice...the peacefulness. The tranquility. No more noise from the system tray. Icons still work too!

### Submitter Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
- [x] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable

<!-- Supplemental comments on the PR with AI prompt/planning information are welcome and encouraged for research and learnings, but not mandatory. Share them as PR comments, not committed to the repository. -->
