### PR TITLE
fix(budgie-menu): hide the menu, not the toplevel, when a drag ends

### DIFF
--- a/src/panel/applets/budgie-menu/BudgieMenuButtons.vala
+++ b/src/panel/applets/budgie-menu/BudgieMenuButtons.vala
@@ -99,8 +99,12 @@ public class MenuButton : Gtk.Button {
 		);
 	}
 
-	private bool hide_toplevel() {
-		this.get_toplevel().hide();
+	private bool hide_menu() {
+		unowned var menu = this.get_ancestor(typeof(BudgieMenuWindow)) as BudgieMenuWindow;
+		if (menu != null) {
+			menu.hide();
+		}
+
 		return false;
 	}
 
@@ -109,7 +113,7 @@ public class MenuButton : Gtk.Button {
 	}
 
 	private new void drag_end(Gdk.DragContext context) {
-		Idle.add(this.hide_toplevel);
+		Idle.add(this.hide_menu);
 	}
 
 	private new void drag_data_get(Gdk.DragContext context, Gtk.SelectionData data, uint info, uint timestamp) {


### PR DESCRIPTION
## Description

MenuButton hid its toplevel once a drag finished. Until 0e3ab119 the menu was a Gtk.Popover, and a widget inside a popover reports the enclosing window as its toplevel, so dragging an app icon onto the desktop hid the panel. Switching the panel position and back re-showed it, which is the workaround in the issue.

The menu is its own Gtk.Window now, which is why this stopped happening on main. Walk up to the BudgieMenuWindow ancestor instead, so we hide the window the button actually belongs to.

Closes #929

Assisted-by: Claude:claude-opus-5[1m]

## Test plan

There is no behavioral change from this commit, it's simply changing the logic of what we are hiding to be more explicit about finding a BudgieMenuWindow. That said, you can test by:

1. Installing the patch
2. Drag an app (non-flatpak unless you have latest commit in budgie-desktop-view) to the desktop, assuming desktop icons enabled
3. Menu closes correctly

### Submitter Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
- [x] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable

<!-- Supplemental comments on the PR with AI prompt/planning information are welcome and encouraged for research and learnings, but not mandatory. Share them as PR comments, not committed to the repository. -->
