### PR TITLE
fix(panel): keep settings in sync after a panel is moved

### DIFF
--- a/src/panel/manager.vala
+++ b/src/panel/manager.vala
@@ -1393,6 +1393,36 @@ namespace Budgie {
 
 			// Load panel again
 			load_panel(uuid, true);
+
+			// Moving leaves the old edge marked as in use, since show_panel() applies
+			// the new position before set_placement() can release it. Left alone,
+			// get_first_position() runs out of edges and new panels stop being created
+			this.update_slots();
+
+			// Anything holding the panel we just closed has to pick up the new one
+			this.panel_added(uuid, panels.lookup(uuid));
+		}
+
+		/**
+		* Recalculate which screen edges are in use from the panels we have now
+		*/
+		void update_slots() {
+			unowned Screen? area = screens.lookup(primary_monitor);
+			if (area == null) {
+				return;
+			}
+
+			string? key = null;
+			Budgie.Panel? val = null;
+
+			area.slots = PanelPosition.NONE;
+
+			// PanelPosition is a bitmask and slots is the set of edges taken, so
+			// walk the panels we have and OR in the edge each one sits on
+			var iter = HashTableIter<string,Budgie.Panel?>(panels);
+			while (iter.next(out key, out val)) {
+				area.slots |= val.position;
+			}
 		}
 
 		/**

--- a/src/panel/settings/settings_main.vala
+++ b/src/panel/settings/settings_main.vala
@@ -344,7 +344,12 @@ namespace Budgie {
 		*/
 		private void on_panel_added(string uuid, Budgie.Toplevel? toplevel) {
 			string content_id = "panel-" + uuid;
-			if (content_id in this.page_map) {
+
+			// A UUID we already have a page for is a panel that was recreated in
+			// place, such as by a move, so hand the page its replacement
+			PanelPage? existing = this.page_map.lookup(content_id) as PanelPage;
+			if (existing != null) {
+				existing.rebind(toplevel);
 				return;
 			}
 			this.add_page(new PanelPage(this.manager, toplevel));

--- a/src/panel/settings/settings_panel.vala
+++ b/src/panel/settings/settings_panel.vala
@@ -29,6 +29,18 @@ namespace Budgie {
 	* PanelPage allows users to change aspects of the fonts used
 	*/
 	public class PanelPage : Budgie.SettingsPage {
+		/* Toplevel properties we mirror into our widgets */
+		private const string[] NEEDED_PROPS = {
+			"position",
+			"intended-size",
+			"spacing",
+			"transparency",
+			"autohide",
+			"shadow-visible",
+			"theme-regions",
+			"dock-mode",
+		};
+
 		unowned Budgie.Toplevel? toplevel;
 		Gtk.Stack stack;
 		Gtk.StackSwitcher switcher;
@@ -124,7 +136,6 @@ namespace Budgie {
 		}
 
 		void rebuild_position_model() {
-			position_model.clear();
 			Gtk.TreeIter iter;
 			const Budgie.PanelPosition[] positions = {
 				Budgie.PanelPosition.TOP,
@@ -132,6 +143,11 @@ namespace Budgie {
 				Budgie.PanelPosition.LEFT,
 				Budgie.PanelPosition.RIGHT,
 			};
+
+			// Clearing the model unsets the active row, so keep the handler out of
+			// it until we've put the panel's own position back
+			SignalHandler.block(this.combobox_position, this.position_id);
+			position_model.clear();
 
 			foreach (var pos in positions) {
 				var used = false;
@@ -157,6 +173,62 @@ namespace Budgie {
 
 				position_model.append(out iter);
 				position_model.set(iter, 0, pos.to_string(), 1, PanelPage.pos_to_display(pos), 2, pos, -1);
+			}
+
+			this.combobox_position.active_id = this.toplevel.position.to_string();
+			SignalHandler.unblock(this.combobox_position, this.position_id);
+		}
+
+		/**
+		* Moving a panel destroys and recreates it, so we point at the new
+		* Toplevel and refresh everything we track from it
+		*/
+		public void rebind(Budgie.Toplevel? toplevel) {
+			// Stop following the panel we were built with, which is closed but
+			// stays alive for as long as anything holds it
+			foreach (var prop in NEEDED_PROPS) {
+				this.toplevel.notify[prop].disconnect(this.panel_notify);
+			}
+
+			this.toplevel = toplevel;
+
+			// Take the new panel's state into our widgets, then follow it instead
+			foreach (var prop in NEEDED_PROPS) {
+				this.update_from_property(prop);
+				this.toplevel.notify[prop].connect_after(this.panel_notify);
+			}
+
+			// Our place in the sidebar is derived from the position
+			this.display_weight = PanelPage.get_panel_weight(this.toplevel);
+
+			this.rebuild_applets_page();
+		}
+
+		/**
+		* Replace the applets tab, as AppletsPage lists the applets of the single
+		* panel it was constructed with
+		*/
+		private void rebuild_applets_page() {
+			Gtk.Widget? existing = this.stack.get_child_by_name("main");
+			var showing = this.stack.get_visible_child_name() == "main";
+
+			if (existing != null) {
+				existing.destroy();
+			}
+
+			var page = this.applets_page();
+			this.stack.add_titled(page, "main", _("Applets"));
+
+			// add_titled() appends, and the applets tab belongs first
+			var position = Value(typeof(int));
+			position.set_int(0);
+			this.stack.child_set_property(page, "position", position);
+
+			page.show_all();
+
+			// Destroying the visible child moved the stack along, so come back
+			if (showing) {
+				this.stack.set_visible_child_name("main");
 			}
 		}
 
@@ -376,19 +448,7 @@ namespace Budgie {
 			combobox_autohide.add_attribute(render, "text", 1);
 			combobox_autohide.set_id_column(0);
 
-			/* Properties we needed to know about */
-			const string[] needed_props = {
-				"position",
-				"intended-size",
-				"spacing",
-				"transparency",
-				"autohide",
-				"shadow-visible",
-				"theme-regions",
-				"dock-mode",
-			};
-
-			foreach (var init in needed_props) {
+			foreach (var init in NEEDED_PROPS) {
 				this.update_from_property(init);
 				this.toplevel.notify[init].connect_after(this.panel_notify);
 			}
@@ -411,11 +471,8 @@ namespace Budgie {
 		private void update_from_property(string property) {
 			switch (property) {
 				case "position":
-					SignalHandler.block(this.combobox_position, this.position_id);
 					rebuild_position_model();
-					this.combobox_position.active_id = this.toplevel.position.to_string();
 					this.title = PanelPage.get_panel_name(toplevel);
-					SignalHandler.unblock(this.combobox_position, this.position_id);
 					break;
 				case "intended-size":
 					SignalHandler.block(this.spinbutton_size, this.size_id);

--- a/src/panel/settings/settings_panel_applets.vala
+++ b/src/panel/settings/settings_panel_applets.vala
@@ -125,8 +125,19 @@ namespace Budgie {
 			toplevel.applet_added.connect(this.applet_added);
 			toplevel.applet_removed.connect(this.applet_removed);
 			toplevel.applets_changed.connect(this.applets_changed);
+			this.destroy.connect(this.on_destroy);
 
 			this.applets_changed();
+		}
+
+		/**
+		* A closed panel still emits for as long as something holds it, so stop
+		* listening before we go away
+		*/
+		private void on_destroy() {
+			this.toplevel.applet_added.disconnect(this.applet_added);
+			this.toplevel.applet_removed.disconnect(this.applet_removed);
+			this.toplevel.applets_changed.disconnect(this.applets_changed);
 		}
 
 		/**


### PR DESCRIPTION
## Description

Moving a panel destroys it and recreates it under a new object, but the settings page kept pointing at the closed one, so its position notify never fired again. Emit panel_added for the recreated panel and rebind the existing page to it instead of returning early on a UUID we already have. The applets page is built against a single panel, so it gets replaced, and it now disconnects from the panel it was built with on destroy.

rebuild_position_model cleared the model without restoring the selection, which is what left the combobox blank. Adding or removing another panel did the same through panels_changed.

Moving also left the edge the panel came from marked as in use, since show_panel applies the new position before set_placement can release it. Once all four edges were claimed there were no slots left and the create panel button did nothing.

Here is a video of it now functioning as expected: https://youtu.be/sgwvVdAULzY

Closes #832

Assisted-by: Claude:claude-opus-5[1m]

## Test plan

1. Prior to use of patch, open up Budgie Desktop Settings and change panel position.
2. Notice that the dropdown gets cleared. You have to restart Budgie Desktop Settings for it to update (but even then you aren't able to create panels against all slots.
3. Install patch and restart budgie panel: `budgie-panel --replace &`
4. Re-open Budgie Desktop Settings, change panel positions, notice it updates immediately

### Submitter Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](DCO.txt)
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-desktop and verified that the patch worked (if needed)
- [x] If AI tools or LLMs were used as part of this contribution, I have read the [AI Policy](https://docs.buddiesofbudgie.org/organization/ai-policy) and commits include `Assisted-by` trailers where applicable

<!-- Supplemental comments on the PR with AI prompt/planning information are welcome and encouraged for research and learnings, but not mandatory. Share them as PR comments, not committed to the repository. -->
